### PR TITLE
Fix update_freq

### DIFF
--- a/src/bar_item.c
+++ b/src/bar_item.c
@@ -63,7 +63,7 @@ void bar_item_script_update(struct bar_item* bar_item, bool forced) {
   if (!bar_item->scripting || (bar_item->update_frequency == 0 && !forced)) return;
   if (strcmp(bar_item->script, "") != 0) {
     bar_item->counter++;
-    if (bar_item->update_frequency < bar_item->counter || forced) { 
+    if (bar_item->update_frequency <= bar_item->counter || forced) {
       bar_item->counter = 0; 
       fork_exec(bar_item->script, NULL);
     }


### PR DESCRIPTION
`~/.config/sketchybar/sketchybarrc`
```
sketchybar -m add item clock right
sketchybar -m set clock update_freq 10
sketchybar -m set clock script ~/.config/sketchybar/plugins/clock
sketchybar -m set clock label_padding_left 15
```

`~/.config/sketchybar/plugins/clock`
```
#!bin/sh
sketchybar -m set clock label "$(date +'%a %m-%d %H:%M:%S')"
```

Look at the clock, the second is not increasing by 10.