### PR TITLE
Window Tags Broken on Monterey

### DIFF
--- a/src/bar.c
+++ b/src/bar.c
@@ -344,10 +344,10 @@ void bar_set_blur_radius(struct bar* bar) {
 void bar_create_window(struct bar* bar) {
   uint32_t set_tags[2] = {
     kCGSStickyTagBit |
-      kCGSModalWindowTagBit |
+      kCGSIgnoreForExposeTagBit,
+    kCGSModalWindowTagBit |
       kCGSDisableShadowTagBit |
-      kCGSHighQualityResamplingTagBit |
-      kCGSIgnoreForExposeTagBit
+      kCGSHighQualityResamplingTagBit
   };
 
   uint32_t clear_tags[2] = { 0, 0 };


### PR DESCRIPTION
According to https://github.com/NUIKit/CGSInternal/blob/master/CGSWindow.h#L69, 

- `kCGSStickyTagBit` and `kCGSIgnoreForExposeTagBit` are hi bits
- `kCGSModalWindowTagBit`, `kCGSDisableShadowTagBit`, and `kCGSHighQualityResamplingTagBit` are lo bits

I've tested on Monterey, it works. Have no lower versions macOS to test, so I'm not sure if it still works on 'em.