### PR TITLE
add missing comma

### DIFF
--- a/src/bar_manager.c
+++ b/src/bar_manager.c
@@ -424,7 +424,7 @@ void bar_manager_serialize(struct bar_manager* bar_manager, FILE* rsp) {
                "\t\"state\": {\n"
                "\t\t\"frozen\": %d,\n"
                "\t\t\"topmost\": %d,\n"
-               "\t\t\"shadow\": %d\n"
+               "\t\t\"shadow\": %d,\n"
                "\t\t\"font_smoothing\": %d\n"
                "\t},\n"
                "\t\"items\": [\n",


### PR DESCRIPTION
right now, it shows things like: 
```
"state": {
		"frozen": 1,
		"topmost": 1,
		"shadow": 0
		"font_smoothing": 0
	},
```
this quick PR fixes it.
```diff
"state": {
		"frozen": 1,
		"topmost": 1,
-		"shadow": 0
+		"shadow": 0,
		"font_smoothing": 0
	},
```