### PR TITLE
Fix memory issues when removing bar items

### DIFF
--- a/src/bar_item.c
+++ b/src/bar_item.c
@@ -29,8 +29,8 @@ void bar_item_inherit_from_item(struct bar_item* bar_item, struct bar_item* ance
   text_destroy(&bar_item->label);
   
   char* name = bar_item->name;
-  char* script = bar_item->name;
-  char* click_script = bar_item->name;
+  char* script = bar_item->script;
+  char* click_script = bar_item->click_script;
 
   memcpy(bar_item, ancestor, sizeof(struct bar_item));
 

--- a/src/bar_manager.c
+++ b/src/bar_manager.c
@@ -107,15 +107,21 @@ void bar_manager_move_item(struct bar_manager* bar_manager, struct bar_item* ite
 
 void bar_manager_remove_item(struct bar_manager* bar_manager, struct bar_item* bar_item) {
   if (bar_manager->bar_item_count <= 0 || !bar_item) return;
-  struct bar_item* tmp[bar_manager->bar_item_count - 1];
-  int count = 0;
-  for (int i = 0; i < bar_manager->bar_item_count; i++) {
-    if (bar_manager->bar_items[i] == bar_item) continue;
-    tmp[count++] = bar_manager->bar_items[i];
+  if (bar_manager->bar_item_count == 1) {
+    free(bar_manager->bar_items);
+    bar_manager->bar_items = NULL;
+    bar_manager->bar_item_count = 0;
+  } else {
+    struct bar_item* tmp[bar_manager->bar_item_count - 1];
+    int count = 0;
+    for (int i = 0; i < bar_manager->bar_item_count; i++) {
+      if (bar_manager->bar_items[i] == bar_item) continue;
+      tmp[count++] = bar_manager->bar_items[i];
+    }
+    bar_manager->bar_item_count--;
+    bar_manager->bar_items = realloc(bar_manager->bar_items, sizeof(struct bar_item*)*bar_manager->bar_item_count);
+    memcpy(bar_manager->bar_items, tmp, sizeof(struct bar_item*)*bar_manager->bar_item_count);
   }
-  bar_manager->bar_item_count--;
-  bar_manager->bar_items = realloc(bar_manager->bar_items, sizeof(struct bar_item*)*bar_manager->bar_item_count);
-  memcpy(bar_manager->bar_items, tmp, sizeof(struct bar_item*)*bar_manager->bar_item_count);
   bar_item_destroy(bar_item);
 }
 


### PR DESCRIPTION
Fixes #110 

## Testing

Tested manually. The repro commands given in #110 now work as expected.
```
sketchybar -m --add item item1 --add item item2
sketchybar -m --remove item1
sketchybar -m --remove item2
```

It's been a while since I've done C, let me know if you want changes made.