### PR TITLE
Fix json output when bar has no items

### DIFF
--- a/src/bar_manager.c
+++ b/src/bar_manager.c
@@ -452,6 +452,6 @@ void bar_manager_serialize(struct bar_manager* bar_manager, FILE* rsp) {
   for (int i = 0; i < bar_manager->bar_item_count; i++) {
     fprintf(rsp, "\t\t \"%s\"", bar_manager->bar_items[i]->name);
     if (i < bar_manager->bar_item_count - 1) fprintf(rsp, ",\n");
-    else fprintf(rsp, "\n\t]\n}\n");
   }
+  fprintf(rsp, "\n\t]\n}\n");
 }


### PR DESCRIPTION
Fixes #112

## Testing
- On a sketchybar instance with no items, and `jq` installed for validation, the following commands should all succeed:
```
sketchybar -m --query bar | jq
# Check for regressions
sketchybar -m --add item test1 --add item test2
sketchybar -m --query bar | jq
```