### PR TITLE
Remove `#include <malloc/_malloc.h>`

### DIFF
--- a/src/group.c
+++ b/src/group.c
@@ -1,7 +1,6 @@
 #include "group.h"
 #include "background.h"
 #include "bar_item.h"
-#include <malloc/_malloc.h>
 #include <stdint.h>
 #include <string.h>
 

--- a/src/message.c
+++ b/src/message.c
@@ -7,7 +7,6 @@
 #include "group.h"
 #include "misc/helpers.h"
 #include <_types/_uint32_t.h>
-#include <malloc/_malloc.h>
 #include <string.h>
 #include <regex.h>
 

--- a/src/misc/env_vars.h
+++ b/src/misc/env_vars.h
@@ -2,7 +2,6 @@
 #define ENV_VARS_H
 
 #include <_types/_uint32_t.h>
-#include <malloc/_malloc.h>
 #include <string.h>
 
 struct key_value_pair {


### PR DESCRIPTION
According to https://stackoverflow.com/questions/12973311/difference-between-stdlib-h-and-malloc-h

<stdlib.h> is enough for malloc, free, calloc, realloc...

It also make sketchybar failed to compile on nix x86_64-darwin:

```
clang src/manifest.m -std=c99 -Wall -DNDEBUG -Ofast -fvisibility=hidden -target x86_64-apple-macos10.13 -F/System/Library/PrivateFrameworks -framework Carbon -framework Cocoa -framework SkyLight  -o bin/sketchybar_x86
In file included from src/manifest.m:15:
src/misc/env_vars.h:5:10: fatal error: 'malloc/_malloc.h' file not found
         ^~~~~~~~~~~~~~~~~~
1 error generated.
make: *** [makefile:49: bin/sketchybar_x86] Error 1
```

see https://github.com/NixOS/nixpkgs/pull/158754#issuecomment-1033867477