### PR TITLE
Mouse scroll events

### DIFF
--- a/src/bar_item.c
+++ b/src/bar_item.c
@@ -241,34 +241,31 @@ void bar_item_on_click(struct bar_item* bar_item, uint32_t type, uint32_t mouse_
   env_vars_destroy(&env_vars);
 }
 
-void bar_item_on_scroll(struct bar_item* bar_item, uint32_t type, long scroll_delta_vert) {
+void bar_item_on_scroll(struct bar_item* bar_item, int scroll_delta) {
   if (!bar_item) return;
 
   struct env_vars env_vars;
   env_vars_init(&env_vars);
   char info_str[256];
   snprintf(info_str, 256, "{\n"
-                         "\t\"scroll_delta_vert\": %ld\n"
-                         "}\n",
-                         scroll_delta_vert                  );
+                          "\t\"delta\": %d\n"
+                          "}\n",
+                          scroll_delta       );
 
   env_vars_set(&env_vars, string_copy("INFO"), string_copy(info_str));
 
   char delta_ver_str[32];
-  snprintf(delta_ver_str, 32, "%ld", scroll_delta_vert);
+  snprintf(delta_ver_str, 32, "%d", scroll_delta);
   env_vars_set(&env_vars,
-               string_copy("DELTA_VERT"),
+               string_copy("SCROLL_DELTA"),
                string_copy(delta_ver_str));
 
-  if (bar_item->scroll_script && strlen(bar_item->scroll_script) > 0) {
-    for (int i = 0; i < bar_item->signal_args.env_vars.count; i++) {
-      env_vars_set(&env_vars,
-                   string_copy(bar_item->signal_args.env_vars.vars[i]->key),
-                   string_copy(bar_item->signal_args.env_vars.vars[i]->value));
-    }
+  if (bar_item->update_mask & UPDATE_MOUSE_SCROLLED)
+    bar_item_update(bar_item,
+                    COMMAND_SUBSCRIBE_MOUSE_SCROLLED,
+                    true,
+                    &env_vars                        );
 
-    fork_exec(bar_item->scroll_script, &env_vars);
-  }
 
   env_vars_destroy(&env_vars);
 }
@@ -317,21 +314,6 @@ static void bar_item_set_click_script(struct bar_item* bar_item, char* script) {
 
   char* path = resolve_path(script);
   bar_item->click_script = path;
-}
-
-static void bar_item_set_scroll_script(struct bar_item* bar_item, char* script) {
-  if (!script) return;
-
-  if (bar_item->scroll_script && strcmp(bar_item->scroll_script, script) == 0) {
-    free(script);
-    return;
-  }
-
-  if (script != bar_item->scroll_script && bar_item->scroll_script)
-    free(bar_item->scroll_script);
-
-  char* path = resolve_path(script);
-  bar_item->scroll_script = path;
 }
 
 static bool bar_item_set_yoffset(struct bar_item* bar_item, int offset) {
@@ -1082,8 +1064,6 @@ void bar_item_parse_set_message(struct bar_item* bar_item, char* message, FILE* 
     bar_item_set_script(bar_item, token_to_string(get_token(&message)));
   } else if (token_equals(property, PROPERTY_CLICK_SCRIPT)) {
     bar_item_set_click_script(bar_item, token_to_string(get_token(&message)));
-  } else if (token_equals(property, PROPERTY_SCROLL_SCRIPT)) {
-    bar_item_set_scroll_script(bar_item, token_to_string(get_token(&message)));
   } else if (token_equals(property, PROPERTY_UPDATE_FREQ)) {
     bar_item->update_frequency = token_to_uint32t(get_token(&message));
   } else if (token_equals(property, PROPERTY_POSITION)) {

--- a/src/bar_item.h
+++ b/src/bar_item.h
@@ -50,7 +50,6 @@ struct bar_item {
 
   char* script;
   char* click_script;
-  char* scroll_script;
   struct signal_args signal_args;
   
   // The position in the bar: l,r,c
@@ -107,7 +106,7 @@ void bar_item_needs_update(struct bar_item* bar_item);
 bool bar_item_update(struct bar_item* bar_item, char* sender, bool forced, struct env_vars* env_vars);
 
 void bar_item_on_click(struct bar_item* bar_item, uint32_t type, uint32_t mouse_button_code, uint32_t modifier, CGPoint point);
-void bar_item_on_scroll(struct bar_item* bar_item, uint32_t type, long scroll_delta_vert);
+void bar_item_on_scroll(struct bar_item* bar_item, int scroll_delta);
 void bar_item_on_drag(struct bar_item* bar_item, CGPoint point);
 void bar_item_mouse_entered(struct bar_item* bar_item);
 void bar_item_mouse_exited(struct bar_item* bar_item);

--- a/src/bar_item.h
+++ b/src/bar_item.h
@@ -50,6 +50,7 @@ struct bar_item {
 
   char* script;
   char* click_script;
+  char* scroll_script;
   struct signal_args signal_args;
   
   // The position in the bar: l,r,c
@@ -106,6 +107,7 @@ void bar_item_needs_update(struct bar_item* bar_item);
 bool bar_item_update(struct bar_item* bar_item, char* sender, bool forced, struct env_vars* env_vars);
 
 void bar_item_on_click(struct bar_item* bar_item, uint32_t type, uint32_t mouse_button_code, uint32_t modifier, CGPoint point);
+void bar_item_on_scroll(struct bar_item* bar_item, uint32_t type, long scroll_delta_vert);
 void bar_item_on_drag(struct bar_item* bar_item, CGPoint point);
 void bar_item_mouse_entered(struct bar_item* bar_item);
 void bar_item_mouse_exited(struct bar_item* bar_item);

--- a/src/bar_manager.c
+++ b/src/bar_manager.c
@@ -781,6 +781,27 @@ void bar_manager_handle_mouse_exited_global(struct bar_manager* bar_manager) {
                                     NULL                                  );
 }
 
+void bar_manager_handle_mouse_scrolled_global(struct bar_manager* bar_manager, long scroll_delta_vert, uint32_t adid) {
+  struct env_vars env_vars;
+  env_vars_init(&env_vars);
+  char delta_ver_str[32];
+  snprintf(delta_ver_str, 32, "%ld", scroll_delta_vert);
+  env_vars_set(&env_vars,
+               string_copy("DELTA_VERT"),
+               string_copy(delta_ver_str));
+
+  char adid_str[32];
+  snprintf(adid_str, 32, "%u", adid);
+  env_vars_set(&env_vars,
+               string_copy("DISPLAY"),
+               string_copy(adid_str));
+
+  bar_manager_custom_events_trigger(bar_manager,
+                                    COMMAND_SUBSCRIBE_MOUSE_SCROLLED_GLOBAL,
+                                    &env_vars                               );
+  env_vars_destroy(&env_vars);
+}
+
 void bar_manager_handle_mouse_entered(struct bar_manager* bar_manager, struct bar_item* bar_item) {
   if (!bar_item) return;
   bar_item_mouse_entered(bar_item);

--- a/src/bar_manager.c
+++ b/src/bar_manager.c
@@ -781,19 +781,27 @@ void bar_manager_handle_mouse_exited_global(struct bar_manager* bar_manager) {
                                     NULL                                  );
 }
 
-void bar_manager_handle_mouse_scrolled_global(struct bar_manager* bar_manager, long scroll_delta_vert, uint32_t adid) {
+void bar_manager_handle_mouse_scrolled_global(struct bar_manager* bar_manager, int scroll_delta, uint32_t adid) {
   struct env_vars env_vars;
   env_vars_init(&env_vars);
   char delta_ver_str[32];
-  snprintf(delta_ver_str, 32, "%ld", scroll_delta_vert);
+  snprintf(delta_ver_str, 32, "%d", scroll_delta);
   env_vars_set(&env_vars,
-               string_copy("DELTA_VERT"),
+               string_copy("SCROLL_DELTA"),
                string_copy(delta_ver_str));
+
+  char info_str[256];
+  snprintf(info_str, 256, "{\n"
+                          "\t\"delta\": %d\n"
+                          "}\n",
+                          scroll_delta       );
+
+  env_vars_set(&env_vars, string_copy("INFO"), string_copy(info_str));
 
   char adid_str[32];
   snprintf(adid_str, 32, "%u", adid);
   env_vars_set(&env_vars,
-               string_copy("DISPLAY"),
+               string_copy("DID"),
                string_copy(adid_str));
 
   bar_manager_custom_events_trigger(bar_manager,

--- a/src/bar_manager.h
+++ b/src/bar_manager.h
@@ -104,7 +104,7 @@ void bar_manager_resize(struct bar_manager* bar_manager);
 
 void bar_manager_handle_mouse_entered_global(struct bar_manager* bar_manager);
 void bar_manager_handle_mouse_exited_global(struct bar_manager* bar_manager);
-void bar_manager_handle_mouse_scrolled_global(struct bar_manager* bar_manager, long scroll_delta_vert, uint32_t did);
+void bar_manager_handle_mouse_scrolled_global(struct bar_manager* bar_manager, int scroll_delta, uint32_t did);
 void bar_manager_handle_mouse_entered(struct bar_manager* bar_manager, struct bar_item* bar_item);
 void bar_manager_handle_mouse_exited(struct bar_manager* bar_manager, struct bar_item* bar_item);
 void bar_manager_handle_front_app_switch(struct bar_manager* bar_manager, char* info);

--- a/src/bar_manager.h
+++ b/src/bar_manager.h
@@ -104,6 +104,7 @@ void bar_manager_resize(struct bar_manager* bar_manager);
 
 void bar_manager_handle_mouse_entered_global(struct bar_manager* bar_manager);
 void bar_manager_handle_mouse_exited_global(struct bar_manager* bar_manager);
+void bar_manager_handle_mouse_scrolled_global(struct bar_manager* bar_manager, long scroll_delta_vert, uint32_t did);
 void bar_manager_handle_mouse_entered(struct bar_manager* bar_manager, struct bar_item* bar_item);
 void bar_manager_handle_mouse_exited(struct bar_manager* bar_manager, struct bar_item* bar_item);
 void bar_manager_handle_front_app_switch(struct bar_manager* bar_manager, char* info);

--- a/src/custom_events.c
+++ b/src/custom_events.c
@@ -26,9 +26,11 @@ void custom_events_init(struct custom_events* custom_events) {
   custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_MOUSE_ENTERED), NULL);
   custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_MOUSE_EXITED), NULL);
   custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_MOUSE_CLICKED), NULL);
+  custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_MOUSE_SCROLLED), NULL);
   custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_SYSTEM_WILL_SLEEP), NULL);
   custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_MOUSE_ENTERED_GLOBAL), NULL);
   custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_MOUSE_EXITED_GLOBAL), NULL);
+  custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_MOUSE_SCROLLED_GLOBAL), NULL);
   custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_VOLUME_CHANGE), NULL);
   custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_BRIGHTNESS_CHANGE), NULL);
   custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_POWER_SOURCE_CHANGE), NULL);

--- a/src/custom_events.h
+++ b/src/custom_events.h
@@ -8,14 +8,16 @@
 #define UPDATE_MOUSE_ENTERED       1ULL << 4
 #define UPDATE_MOUSE_EXITED        1ULL << 5
 #define UPDATE_MOUSE_CLICKED       1ULL << 6
-#define UPDATE_SYSTEM_WILL_SLEEP   1ULL << 7
-#define UPDATE_ENTERED_GLOBAL      1ULL << 8
-#define UPDATE_EXITED_GLOBAL       1ULL << 9
-#define UPDATE_VOLUME_CHANGE       1ULL << 10
-#define UPDATE_BRIGHTNESS_CHANGE   1ULL << 11
-#define UPDATE_POWER_SOURCE_CHANGE 1ULL << 12
-#define UPDATE_WIFI_CHANGE         1ULL << 13
-#define UPDATE_MEDIA_CHANGE        1ULL << 14
+#define UPDATE_MOUSE_SCROLLED      1ULL << 7
+#define UPDATE_SYSTEM_WILL_SLEEP   1ULL << 8
+#define UPDATE_ENTERED_GLOBAL      1ULL << 9
+#define UPDATE_EXITED_GLOBAL       1ULL << 10
+#define UPDATE_SCROLLED_GLOBAL     1ULL << 11
+#define UPDATE_VOLUME_CHANGE       1ULL << 12
+#define UPDATE_BRIGHTNESS_CHANGE   1ULL << 13
+#define UPDATE_POWER_SOURCE_CHANGE 1ULL << 14
+#define UPDATE_WIFI_CHANGE         1ULL << 15
+#define UPDATE_MEDIA_CHANGE        1ULL << 16
 
 extern void* g_workspace_context;
 extern void workspace_create_custom_observer(void** context, char* name);

--- a/src/event.h
+++ b/src/event.h
@@ -26,6 +26,7 @@ EVENT_CALLBACK(EVENT_HANDLER_MOUSE_UP);
 EVENT_CALLBACK(EVENT_HANDLER_MOUSE_DRAGGED);
 EVENT_CALLBACK(EVENT_HANDLER_MOUSE_ENTERED);
 EVENT_CALLBACK(EVENT_HANDLER_MOUSE_EXITED);
+EVENT_CALLBACK(EVENT_HANDLER_MOUSE_SCROLLED);
 EVENT_CALLBACK(EVENT_HANDLER_VOLUME_CHANGED);
 EVENT_CALLBACK(EVENT_HANDLER_WIFI_CHANGED);
 EVENT_CALLBACK(EVENT_HANDLER_BRIGHTNESS_CHANGED);
@@ -62,6 +63,7 @@ enum event_type {
     MOUSE_DRAGGED,
     MOUSE_ENTERED,
     MOUSE_EXITED,
+    MOUSE_SCROLLED,
     VOLUME_CHANGED,
     WIFI_CHANGED,
     BRIGHTNESS_CHANGED,
@@ -92,6 +94,7 @@ static const char *event_type_str[] = {
     [MOUSE_DRAGGED]                  = "mouse_dragged",
     [MOUSE_ENTERED]                  = "mouse_entered",
     [MOUSE_EXITED]                   = "mouse_exited",
+    [MOUSE_SCROLLED]                 = "mouse_scrolled",
     [VOLUME_CHANGED]                 = "volume_changed",
     [WIFI_CHANGED]                   = "wifi_changed",
     [BRIGHTNESS_CHANGED]             = "brightness_changed",
@@ -114,6 +117,7 @@ static event_callback *event_handler[] = {
     [MOUSE_DRAGGED]                  = EVENT_HANDLER_MOUSE_DRAGGED,
     [MOUSE_ENTERED]                  = EVENT_HANDLER_MOUSE_ENTERED,
     [MOUSE_EXITED]                   = EVENT_HANDLER_MOUSE_EXITED,
+    [MOUSE_SCROLLED]                 = EVENT_HANDLER_MOUSE_SCROLLED,
     [VOLUME_CHANGED]                 = EVENT_HANDLER_VOLUME_CHANGED,
     [WIFI_CHANGED]                   = EVENT_HANDLER_WIFI_CHANGED,
     [BRIGHTNESS_CHANGED]             = EVENT_HANDLER_BRIGHTNESS_CHANGED,

--- a/src/misc/defines.h
+++ b/src/misc/defines.h
@@ -82,6 +82,7 @@
 #define PROPERTY_UPDATE_FREQ                   "update_freq"
 #define PROPERTY_SCRIPT                        "script"
 #define PROPERTY_CLICK_SCRIPT                  "click_script"
+#define PROPERTY_SCROLL_SCRIPT                 "scroll_script"
 #define PROPERTY_ICON                          "icon"
 #define PROPERTY_YOFFSET                       "y_offset"
 #define PROPERTY_WIDTH                         "width"
@@ -120,8 +121,10 @@
 #define COMMAND_SUBSCRIBE_MOUSE_ENTERED        "mouse.entered"
 #define COMMAND_SUBSCRIBE_MOUSE_EXITED         "mouse.exited"
 #define COMMAND_SUBSCRIBE_MOUSE_CLICKED        "mouse.clicked"
+#define COMMAND_SUBSCRIBE_MOUSE_SCROLLED       "mouse.scrolled"
 #define COMMAND_SUBSCRIBE_MOUSE_ENTERED_GLOBAL "mouse.entered.global"
 #define COMMAND_SUBSCRIBE_MOUSE_EXITED_GLOBAL  "mouse.exited.global"
+#define COMMAND_SUBSCRIBE_MOUSE_SCROLLED_GLOBAL "mouse.scrolled.global"
 
 #define DOMAIN_QUERY                           "--query"
 #define COMMAND_QUERY_DEFAULT_ITEMS            "default_menu_items"

--- a/src/misc/defines.h
+++ b/src/misc/defines.h
@@ -82,7 +82,6 @@
 #define PROPERTY_UPDATE_FREQ                   "update_freq"
 #define PROPERTY_SCRIPT                        "script"
 #define PROPERTY_CLICK_SCRIPT                  "click_script"
-#define PROPERTY_SCROLL_SCRIPT                 "scroll_script"
 #define PROPERTY_ICON                          "icon"
 #define PROPERTY_YOFFSET                       "y_offset"
 #define PROPERTY_WIDTH                         "width"

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -8,7 +8,8 @@ static const EventTypeSpec mouse_events [] = {
     { kEventClassMouse, kEventMouseUp },
     { kEventClassMouse, kEventMouseDragged },
     { kEventClassMouse, kEventMouseEntered },
-    { kEventClassMouse, kEventMouseExited }
+    { kEventClassMouse, kEventMouseExited },
+    { kEventClassMouse, kEventMouseWheelMoved }
 };
 
 
@@ -43,6 +44,13 @@ static pascal OSStatus mouse_handler(EventHandlerCallRef next, EventRef e, void 
                                          MOUSE_EXITED,
                                          (void *) CFRetain(CopyEventCGEvent(e)));
       event_loop_post(&g_event_loop, event); 
+      break;
+    }
+    case kEventMouseWheelMoved: {
+      struct event *event = event_create(&g_event_loop,
+                                         MOUSE_SCROLLED,
+                                         (void *) CFRetain(CopyEventCGEvent(e)));
+      event_loop_post(&g_event_loop, event);
       break;
     }
     default:


### PR DESCRIPTION
Adds `mouse.scrolled` and `mouse.scrolled.global`.

Considerations:
- This currently captures only vertical scrolling -- horizontal scrolling still fires the event but with a zero delta. Follow-up would be to expose the horizontal delta as well and/or combine them into one signal.
- I think this only applies to mouse wheels (so no track pad, but we have proper gestures there).

`mouse.scrolled` I could see being useful for changing volume. `mouse.scrolled.global` I use to replicate the scroll feature of i3, where scrolling on the empty bar switches workspaces on the screen under mouse (not necessarily the focused screen).

Amended [these dotfiles](https://github.com/FelixKratz/dotfiles/tree/master/.config/sketchybar) like so:

`plugins/yabai.sh`
```bash
mouse_scrolled() {
  if [ $1 -lt 0 ]; then
    id="$(yabai -m query --spaces --display $2 | jq 'sort_by(.index) | .[map(."is-visible") | index(true) - 1].index')" && yabai -m space --focus "${id}"
  elif [ $1 -gt 0 ]; then
    id="$(yabai -m query --spaces --display $2 | jq 'sort_by(.index) | reverse | .[map(."is-visible") | index(true) - 1].index')" && yabai -m space --focus "${id}"
  fi
}

case "$SENDER" in
  "mouse.clicked") mouse_clicked
  ;;
  "forced") exit 0
  ;;
  "window_focus") window_state 
  ;;
  "windows_on_spaces" | "space_change") windows_on_spaces
  ;;
  "mouse.scrolled.global") mouse_scrolled "$DELTA_VERT" "$DISPLAY"
esac
```

`items/yabai.sh`
```bash
sketchybar --add event window_focus            \
           --add event windows_on_spaces       \
           --add item yabai left               \
           --set yabai "${yabai[@]}"           \
           --subscribe yabai window_focus      \
                             space_change      \
                             windows_on_spaces \
                             mouse.clicked     \
                             mouse.scrolled.global
```