### PR TITLE
Replace Carbon Event Loop

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,5 @@
 CFLAGS   = -std=c99 -Wall -Ofast -ffast-math -fvisibility=hidden -fno-common
-LIBS     = -framework Carbon \
-	   -framework AppKit \
+LIBS     = -framework AppKit \
            -framework CoreAudio \
            -framework CoreWLAN \
 	   -framework IOKit \

--- a/src/bar_item.c
+++ b/src/bar_item.c
@@ -168,6 +168,18 @@ void bar_item_needs_update(struct bar_item* bar_item) {
   bar_item->needs_update = true;
 }
 
+void bar_item_cancel_drag(struct bar_item* bar_item) {
+  if (bar_item->has_slider) {
+    char perc_str[8];
+    snprintf(perc_str, 8, "%d", bar_item->slider.percentage);
+    env_vars_set(&bar_item->signal_args.env_vars,
+                 string_copy("PERCENTAGE"),
+                 string_copy(perc_str)           );
+
+    slider_cancel_drag(&bar_item->slider);
+  }
+}
+
 void bar_item_on_drag(struct bar_item* bar_item, CGPoint point) {
   if (bar_item->has_slider) {
     if (slider_handle_drag(&bar_item->slider, point)) {
@@ -210,12 +222,7 @@ void bar_item_on_click(struct bar_item* bar_item, uint32_t type, uint32_t mouse_
         bar_item_needs_update(bar_item);
       }
 
-      char perc_str[8];
-      snprintf(perc_str, 8, "%d", bar_item->slider.percentage);
-      env_vars_set(&bar_item->signal_args.env_vars,
-                   string_copy("PERCENTAGE"),
-                   string_copy(perc_str)           );
-      bar_item->slider.is_dragged = false;
+      bar_item_cancel_drag(bar_item);
     } else {
       env_vars_destroy(&env_vars);
       return;

--- a/src/bar_item.h
+++ b/src/bar_item.h
@@ -110,6 +110,7 @@ void bar_item_on_scroll(struct bar_item* bar_item, int scroll_delta);
 void bar_item_on_drag(struct bar_item* bar_item, CGPoint point);
 void bar_item_mouse_entered(struct bar_item* bar_item);
 void bar_item_mouse_exited(struct bar_item* bar_item);
+void bar_item_cancel_drag(struct bar_item* bar_item);
 
 void bar_item_append_associated_space(struct bar_item* bar_item, uint32_t bit);
 void bar_item_append_associated_display(struct bar_item* bar_item, uint32_t bit);

--- a/src/bar_manager.c
+++ b/src/bar_manager.c
@@ -6,6 +6,7 @@
 #include "wifi.h"
 #include "volume.h"
 #include "power.h"
+#include "mouse.h"
 
 extern void forced_front_app_event();
 
@@ -768,13 +769,21 @@ void bar_manager_display_changed(struct bar_manager* bar_manager) {
   bar_manager_handle_space_change(bar_manager, true);
 }
 
+void bar_manager_cancel_drag(struct bar_manager* bar_manager) {
+  for (uint32_t i = 0; i < bar_manager->bar_item_count; i++) {
+    bar_item_cancel_drag(bar_manager->bar_items[i]);
+  }
+}
+
 void bar_manager_handle_mouse_entered_global(struct bar_manager* bar_manager) {
+  SLSSetBackgroundEventMask(g_connection, g_mouse_events);
   bar_manager_custom_events_trigger(bar_manager,
                                     COMMAND_SUBSCRIBE_MOUSE_ENTERED_GLOBAL,
                                     NULL                                   );
 }
 
 void bar_manager_handle_mouse_exited_global(struct bar_manager* bar_manager) {
+  SLSSetBackgroundEventMask(g_connection, 0);
   bar_manager_custom_events_trigger(bar_manager,
                                     COMMAND_SUBSCRIBE_MOUSE_EXITED_GLOBAL,
                                     NULL                                  );

--- a/src/event.c
+++ b/src/event.c
@@ -186,7 +186,7 @@ static void event_mouse_exited(void* context) {
   if ((bar = bar_manager_get_bar_by_wid(&g_bar_manager, wid))) {
     origin_window = &bar->window;
     popup_target = bar_manager_get_popup_by_point(&g_bar_manager,
-        point          );
+                                                  point          );
     over_target = (popup_target != NULL);
   }
   else if ((popup = bar_manager_get_popup_by_wid(&g_bar_manager, wid))) {

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -1,68 +1,23 @@
-#include <Carbon/Carbon.h>
 #include "mouse.h"
 
-static const EventTypeSpec mouse_events [] = {
-    { kEventClassMouse, kEventMouseDown },
-    { kEventClassMouse, kEventMouseUp },
-    { kEventClassMouse, kEventMouseDragged },
-    { kEventClassMouse, kEventMouseEntered },
-    { kEventClassMouse, kEventMouseExited },
-    { kEventClassMouse, kEventMouseWheelMoved }
-};
-
-
-static pascal OSStatus mouse_handler(EventHandlerCallRef next, EventRef e, void *data) {
-  switch (GetEventKind(e)) {
-    case kEventMouseUp: {
-      CGEventRef cg_event = CopyEventCGEvent(e);
-      struct event event = { (void *) cg_event, MOUSE_UP };
-
-      event_post(&event);
-      CFRelease(cg_event);
-      break;
-    }
-    case kEventMouseDragged: {
-      CGEventRef cg_event = CopyEventCGEvent(e);
-      struct event event = { (void *) cg_event, MOUSE_DRAGGED };
-
-      event_post(&event);
-      CFRelease(cg_event);
-      break;
-    }
-    case kEventMouseEntered: {
-      CGEventRef cg_event = CopyEventCGEvent(e);
-      struct event event = { (void *) cg_event, MOUSE_ENTERED };
-
-      event_post(&event); 
-      CFRelease(cg_event);
-      break;
-    }
-    case kEventMouseExited: {
-      CGEventRef cg_event = CopyEventCGEvent(e);
-      struct event event = { (void *) cg_event, MOUSE_EXITED };
-
-      event_post(&event); 
-      CFRelease(cg_event);
-      break;
-    }
-    case kEventMouseWheelMoved: {
-      CGEventRef cg_event = CopyEventCGEvent(e);
-      struct event event = { (void *) cg_event, MOUSE_SCROLLED };
-
-      event_post(&event);
-      CFRelease(cg_event);
-      break;
-    }
-    default:
-      break;
-  }
-
-  return CallNextEventHandler(next, e);
-}
-
-void mouse_begin(void) {
-  InstallEventHandler(GetEventDispatcherTarget(),
-                      NewEventHandlerUPP(mouse_handler),
-                      GetEventTypeCount(mouse_events),
-                      mouse_events, 0, 0);
+bool mouse_handle_event(CGEventType type, CGEventRef cg_event) {
+  if (type == kCGEventOtherMouseUp
+      || type == kCGEventLeftMouseUp
+      || type == kCGEventRightMouseUp) {
+    struct event event = { (void *) cg_event, MOUSE_UP };
+    event_post(&event);
+  } else if (type == kCGEventLeftMouseDragged) {
+    struct event event = { (void *) cg_event, MOUSE_DRAGGED };
+    event_post(&event);
+  } else if (type == 0x8) {
+    struct event event = { (void *) cg_event, MOUSE_ENTERED };
+    event_post(&event); 
+  } else if (type == 0x9) {
+    struct event event = { (void *) cg_event, MOUSE_EXITED };
+    event_post(&event); 
+  } else if (type == kCGEventScrollWheel) {
+    struct event event = { (void *) cg_event, MOUSE_SCROLLED };
+    event_post(&event);
+  } else return false;
+  return true;
 }

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -1,4 +1,11 @@
 #pragma once
 #include "event.h"
 
-void mouse_begin(void);
+static const CGEventMask g_mouse_events
+                                     = CGEventMaskBit(kCGEventLeftMouseUp)
+                                     | CGEventMaskBit(kCGEventRightMouseUp)
+                                     | CGEventMaskBit(kCGEventOtherMouseUp)
+                                     | CGEventMaskBit(kCGEventLeftMouseDragged)
+                                     | CGEventMaskBit(kCGEventScrollWheel);
+      
+bool mouse_handle_event(CGEventType type, CGEventRef cg_event);

--- a/src/sketchybar.c
+++ b/src/sketchybar.c
@@ -36,6 +36,8 @@ extern CGEventRef SLEventCreateNextEvent(int cid);
 extern void _CFMachPortSetOptions(CFMachPortRef mach_port, int options);
 extern CGError SLSSetBackgroundEventMask(int cid, int mask);
 extern CGError SLSSetEventMask(int cid, int mask);
+extern CGError SLSGetCoalesceEventsMask(uint32_t cid, int64_t* mask_out);
+extern CGError SLSCoalesceEventsInMask(uint32_t cid, int64_t mask);
 
 int g_connection;
 CFTypeRef g_transaction;
@@ -223,8 +225,12 @@ int main(int argc, char **argv) {
 
   exec_config_file();
   begin_receiving_config_change_events();
-  SLSSetBackgroundEventMask(g_connection, g_mouse_events);
   SLSSetEventMask(g_connection, g_mouse_events);
+
+  int64_t mask;
+  SLSGetCoalesceEventsMask(g_connection, &mask);
+  mask = (uint32_t)mask & 0xf67fff1f;
+  SLSCoalesceEventsInMask(g_connection, mask);
   
   mach_port_t port;
   CGError error = SLSGetEventPort(g_connection, &port);

--- a/src/slider.c
+++ b/src/slider.c
@@ -29,6 +29,10 @@ uint32_t slider_get_percentage_for_point(struct slider* slider, CGPoint point) {
   return min(percentage, 100);
 }
 
+void slider_cancel_drag(struct slider* slider) {
+  slider->is_dragged = false;
+}
+
 bool slider_handle_drag(struct slider* slider, CGPoint point) {
   uint32_t percentage = slider_get_percentage_for_point(slider, point);
   slider->is_dragged = true;

--- a/src/slider.h
+++ b/src/slider.h
@@ -23,6 +23,7 @@ bool slider_handle_drag(struct slider* slider, CGPoint point);
 uint32_t slider_get_percentage_for_point(struct slider* slider, CGPoint point);
 uint32_t slider_get_length(struct slider* slider);
 
+void slider_cancel_drag(struct slider* slider);
 void slider_destroy(struct slider* slider);
 void slider_serialize(struct slider* slider, char* indent, FILE* rsp);
 bool slider_parse_sub_domain(struct slider* graph, FILE* rsp, struct token property, char* message);

--- a/src/window.c
+++ b/src/window.c
@@ -1,5 +1,6 @@
 #include "window.h"
 #include "bar_manager.h"
+#include "mouse.h"
 
 extern struct bar_manager g_bar_manager;
 extern int64_t g_disable_capture;
@@ -52,18 +53,9 @@ void window_create(struct window* window, CGRect frame) {
   SLSSetWindowTags(g_connection, window->id, &set_tags, 64);
   SLSClearWindowTags(g_connection, window->id, &clear_tags, 64);
   SLSSetWindowOpacity(g_connection, window->id, 0);
+  SLSSetWindowEventMask(g_connection, window->id, g_mouse_events);
 
-  const void* keys[] = { CFSTR("CGWindowContextShouldUseCA") };
-  const void* values[] = { kCFBooleanTrue };
-  CFDictionaryRef dict = CFDictionaryCreate(NULL,
-                                            keys,
-                                            values,
-                                            1,
-                                            &kCFTypeDictionaryKeyCallBacks,
-                                            &kCFTypeDictionaryValueCallBacks);
-
-  window->context = SLWindowContextCreate(g_connection, window->id, dict);
-  CFRelease(dict);
+  window->context = SLWindowContextCreate(g_connection, window->id, NULL);
 
   CGContextSetInterpolationQuality(window->context, kCGInterpolationNone);
   window->needs_move = false;

--- a/src/window.c
+++ b/src/window.c
@@ -49,11 +49,11 @@ void window_create(struct window* window, CGRect frame) {
   window->id = (uint32_t)id;
   CFRelease(frame_region);
 
+  SLSSetWindowEventMask(g_connection, window->id, g_mouse_events);
   SLSSetWindowResolution(g_connection, window->id, 2.0f);
   SLSSetWindowTags(g_connection, window->id, &set_tags, 64);
   SLSClearWindowTags(g_connection, window->id, &clear_tags, 64);
   SLSSetWindowOpacity(g_connection, window->id, 0);
-  SLSSetWindowEventMask(g_connection, window->id, g_mouse_events);
 
   window->context = SLWindowContextCreate(g_connection, window->id, NULL);
 

--- a/src/window.h
+++ b/src/window.h
@@ -3,6 +3,7 @@
 
 extern CGError SLSSetWindowEventShape(int cid, int wid, CFTypeRef region);
 extern CGError SLSSetWindowEventMask(int cid, int wid, int mask);
+extern CGError SLSSetBackgroundEventMask(int cid, int mask);
 
 extern CFTypeRef SLSTransactionCreate(int cid);
 extern CGError SLSTransactionOrderWindow(CFTypeRef transaction, uint32_t wid, int mode, uint32_t relativeToWID);

--- a/src/window.h
+++ b/src/window.h
@@ -1,7 +1,10 @@
 #pragma once
 #include "misc/helpers.h"
 
-CFTypeRef SLSTransactionCreate(int cid);
+extern CGError SLSSetWindowEventShape(int cid, int wid, CFTypeRef region);
+extern CGError SLSSetWindowEventMask(int cid, int wid, int mask);
+
+extern CFTypeRef SLSTransactionCreate(int cid);
 extern CGError SLSTransactionOrderWindow(CFTypeRef transaction, uint32_t wid, int mode, uint32_t relativeToWID);
 extern CGError SLSTransactionSetWindowLevel(CFTypeRef transaction, uint32_t wid, int level);
 extern CGError SLSTransactionSetWindowShape(CFTypeRef transaction, uint32_t wid, float x_offset, float y_offset, CFTypeRef shape);


### PR DESCRIPTION
This removes all uses of the Carbon framework by pulling the relevant events directly from the window server and adding the mach event port as a runloop source. This is probably as low level (and efficient) as it gets in terms of the event system.

Some testing is required before this is merged as it replaces the core run loop of the program. Any help with testing the functionality of the bar is appreciated.