### PR TITLE
Update volume icons

### DIFF
--- a/plugins/volume.sh
+++ b/plugins/volume.sh
@@ -7,13 +7,13 @@ if [ "$SENDER" = "volume_change" ]; then
   VOLUME=$INFO
 
   case $VOLUME in
-    [6-9][0-9]|100) ICON="墳"
+    [6-9][0-9]|100) ICON="󰕾"
     ;;
-    [3-5][0-9]) ICON="奔"
+    [3-5][0-9]) ICON="󰖀"
     ;;
-    [1-9]|[1-2][0-9]) ICON="奄"
+    [1-9]|[1-2][0-9]) ICON="󰕿"
     ;;
-    *) ICON="婢"
+    *) ICON="󰖁"
   esac
 
   sketchybar --set $NAME icon="$ICON" label="$VOLUME%"


### PR DESCRIPTION
I went through the volume icons in `plugins/volume.sh` and updated them to the new matching Nerd Font Icon variants. Luckily, the broken icon could still be used in the [Cheat Sheet search](https://www.nerdfonts.com/cheat-sheet) to find the correct matching icon. 😄

Updated icons (a bit hard to see from the "Files changed" tab).
![image](https://github.com/FelixKratz/SketchyBar/assets/17124245/8f9acdea-b898-4e85-81b9-c9c01ae48706)

Example of replaced volume_off icon.
![image](https://github.com/FelixKratz/SketchyBar/assets/17124245/de1e4de2-ecde-4f70-8233-24e9ed661d88)
![image](https://github.com/FelixKratz/SketchyBar/assets/17124245/3fa4f60f-f86f-42cc-a923-49cea8c3cc7e)
