### PR TITLE
chore: bump release version

### DIFF
--- a/src/sketchybar.c
+++ b/src/sketchybar.c
@@ -26,7 +26,7 @@
 
 #define MAJOR 2
 #define MINOR 19
-#define PATCH 0
+#define PATCH 1
 
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
 extern CGError SLSWindowManagementBridgeSetDelegate(void* delegate);


### PR DESCRIPTION
--version returns incorrect value. bumping to match. Had to create a small patch workaround for our packaging validation https://github.com/NixOS/nixpkgs/pull/266760/files#diff-726b3d7fe8d6da7ba3c055c5838db46f75f330e14a266fb9ba49251eaec8a1baR47 