### PR TITLE
fix default color for graphs

### DIFF
--- a/src/graph.c
+++ b/src/graph.c
@@ -9,8 +9,8 @@ void graph_init(struct graph* graph) {
   graph->overrides_fill_color = false;
   graph->enabled = true;
 
-  color_init(&graph->line_color, 0xcccccc);
-  color_init(&graph->fill_color, 0xcccccc);
+  color_init(&graph->line_color, 0xffcccccc);
+  color_init(&graph->fill_color, 0xffcccccc);
 }
 
 void graph_setup(struct graph* graph, uint32_t width) {


### PR DESCRIPTION
I was wondering why the graph was not visible to me by default. The default colors are not set as ARGB, so I think this should be the fix.
tested successfully on my local system

disclaimer: not a c developer :)
