### PR TITLE
fix off-by-1 error for center items

### DIFF
--- a/src/bar.c
+++ b/src/bar.c
@@ -241,7 +241,7 @@ static void bar_calculate_bounds_top_bottom(struct bar* bar) {
                                           0                                  );
 
   uint32_t bar_center_first_item_x = (bar->window.frame.size.width
-                                      - center_length) / 2 - 1;
+                                      - center_length) / 2;
 
   uint32_t bar_center_right_first_item_x = (bar->window.frame.size.width
                                             + notch_width) / 2;


### PR DESCRIPTION
Hi there,

I have noticed another off-by-one error for item centering that was leftover after #592. I am making a thin bar right under the notch so that teeny-tiny difference was actually noticeable.