### PR TITLE
Show in Fullscreen Option

### DIFF
--- a/src/bar_manager.h
+++ b/src/bar_manager.h
@@ -26,6 +26,7 @@ struct bar_manager {
   bool might_need_clipping;
   bool bar_needs_update;
   bool bar_needs_resize;
+  bool show_in_fullscreen;
 
   uint32_t displays;
   char position;
@@ -78,6 +79,7 @@ bool bar_manager_set_topmost(struct bar_manager* bar_manager, char level, bool t
 bool bar_manager_set_sticky(struct bar_manager *bar_manager, bool sticky);
 bool bar_manager_set_shadow(struct bar_manager* bar_manager, bool shadow);
 bool bar_manager_set_font_smoothing(struct bar_manager* bar_manager, bool smoothing);
+bool bar_manager_set_show_in_fullscreen(struct bar_manager* bar_manager, bool show_in_fullscreen);
 bool bar_manager_set_notch_width(struct bar_manager* bar_manager, uint32_t width);
 bool bar_manager_set_notch_offset(struct bar_manager* bar_manager, uint32_t offset);
 bool bar_manager_set_notch_display_height(struct bar_manager* bar_manager, uint32_t offset);

--- a/src/misc/defines.h
+++ b/src/misc/defines.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #define DOMAIN_ADD                             "--add"
-#define COMMAND_ADD_ITEM                       "item"                                  
+#define COMMAND_ADD_ITEM                       "item"
 #define COMMAND_ADD_COMPONENT                  "component"
 #define COMMAND_ADD_EVENT                      "event"
 
@@ -107,6 +107,7 @@
 #define PROPERTY_SPACE                         "space"
 #define PROPERTY_TOPMOST                       "topmost"
 #define PROPERTY_STICKY                        "sticky"
+#define PROPERTY_SHOW_IN_FULLSCREEN            "show_in_fullscreen"
 #define PROPERTY_HIDDEN                        "hidden"
 #define PROPERTY_FONT_SMOOTHING                "font_smoothing"
 #define PROPERTY_SHADOW                        "shadow"
@@ -167,7 +168,7 @@
 #define ARGUMENT_DISPLAY_MAIN                  "main"
 #define ARGUMENT_DISPLAY_ALL                   "all"
 
-#define ARGUMENT_UPDATES_WHEN_SHOWN            "when_shown" 
+#define ARGUMENT_UPDATES_WHEN_SHOWN            "when_shown"
 #define ARGUMENT_DYNAMIC                       "dynamic"
 
 #define ARGUMENT_WINDOW                        "window"


### PR DESCRIPTION
This closes #594 by creating a configuration option `show_in_fullscreen` that when combined with `sticky=on` and `topmost=on` keeps SketchyBar visible over fullscreen applications.