### PR TITLE
feat: truetype font features

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -53,7 +53,6 @@ void font_create_ctfont(struct font* font) {
 
 
   if (font->features) {
-    CFAllocatorRef default_allocator = CFAllocatorGetDefault();
     
     char* features_copy = string_copy(font->features);
     char* feature = strtok(features_copy, ",");
@@ -63,8 +62,8 @@ void font_create_ctfont(struct font* font) {
       int feat_value = 0;
 
       if (sscanf(feature, "%d:%d", &feat_name, &feat_value) == 2) {
-        CFNumberRef name = CFNumberCreate(default_allocator, kCFNumberIntType, &feat_name);
-        CFNumberRef value = CFNumberCreate(default_allocator, kCFNumberIntType, &feat_value);
+        CFNumberRef name = CFNumberCreate(NULL, kCFNumberIntType, &feat_name);
+        CFNumberRef value = CFNumberCreate(NULL, kCFNumberIntType, &feat_value);
 
         descriptor = CTFontDescriptorCreateCopyWithFeature(descriptor, name, value);
 
@@ -77,7 +76,6 @@ void font_create_ctfont(struct font* font) {
 
     free(feature);
     free(features_copy);
-    CFRelease(default_allocator);
   }
 
   font->ct_font = CTFontCreateWithFontDescriptor(descriptor, 0.0, NULL);

--- a/src/font.c
+++ b/src/font.c
@@ -140,7 +140,6 @@ void font_create_ctfont(struct font* font) {
       feature = strtok(NULL, ",");
     }
 
-    free(feature);
     free(features_copy);
   }
 

--- a/src/font.c
+++ b/src/font.c
@@ -2,6 +2,60 @@
 #include "animation.h"
 #include "bar_manager.h"
 
+struct feature_mapping {
+  char opentype_tag[5];
+  int truetype_feature;
+  int truetype_selector;
+};
+
+// Non-exhaustive list of OpenType tags and corresponding TrueType features and selectors
+struct feature_mapping feature_mappings[] = {
+  {"liga", kLigaturesType, kCommonLigaturesOnSelector},
+  {"dlig", kLigaturesType, kRareLigaturesOnSelector},
+
+  {"tnum", kNumberSpacingType, kMonospacedNumbersSelector}, 
+  {"pnum", kNumberSpacingType, kProportionalNumbersSelector}, 
+
+  {"smcp", kLowerCaseType, kLowerCaseSmallCapsSelector},
+  {"c2sc", kUpperCaseType, kUpperCaseSmallCapsSelector},
+
+  {"onum", kNumberCaseType, kLowerCaseNumbersSelector},
+  {"lnum", kNumberCaseType, kUpperCaseNumbersSelector},
+
+  {"afrc", kFractionsType, kVerticalFractionsSelector},
+  {"frac", kFractionsType, kDiagonalFractionsSelector},
+
+  {"subs", kVerticalPositionType, kInferiorsSelector},
+  {"sups", kVerticalPositionType, kSuperiorsSelector},
+
+  {"zero", kTypographicExtrasType, kSlashedZeroOnSelector},
+
+  {"swsh", kContextualAlternatesType, kSwashAlternatesOnSelector},
+  {"cswh", kContextualAlternatesType, kContextualSwashAlternatesOnSelector},
+
+  {"calt", kContextualAlternatesType, kContextualAlternatesOnSelector},
+
+  // kStylisticAlternativesType = 35
+  {"salt", 35,  2},
+  {"ss01", 35,  2}, {"ss02", 35, 4},  {"ss03", 35,  6}, {"ss04", 35,  8},
+  {"ss05", 35, 10}, {"ss06", 35, 12}, {"ss07", 35, 14}, {"ss08", 35, 16},
+  {"ss09", 35, 18}, {"ss10", 35, 20}, {"ss11", 35, 22}, {"ss12", 35, 24},
+  {"ss13", 35, 26}, {"ss14", 35, 28}, {"ss15", 35, 30}, {"ss16", 35, 32},
+  {"ss17", 35, 34}, {"ss18", 35, 36}, {"ss19", 35, 38}, {"ss20", 35, 40},
+
+  {"", 0, 0}
+};
+
+void get_truetype_feature(const char* opentype_tag, int* truetype_feature, int* truetype_selector) {
+  for (int i = 0; feature_mappings[i].opentype_tag[0] != '\0'; ++i) {
+    if (strcmp(feature_mappings[i].opentype_tag, opentype_tag) == 0) {
+      *truetype_feature = feature_mappings[i].truetype_feature;
+      *truetype_selector = feature_mappings[i].truetype_selector;
+      return;
+    }
+  }
+}
+
 void font_register(char* font_path) {
   CFStringRef url_string = CFStringCreateWithCString(kCFAllocatorDefault,
                                                      font_path,
@@ -51,19 +105,29 @@ void font_create_ctfont(struct font* font) {
 
   if (font->ct_font) CFRelease(font->ct_font);
 
-
   if (font->features) {
-    
     char* features_copy = string_copy(font->features);
     char* feature = strtok(features_copy, ",");
 
     while (feature) {
-      int feat_name = 0;
-      int feat_value = 0;
+      int feature_name = 0;
+      int feature_selector = 0;
 
-      if (sscanf(feature, "%d:%d", &feat_name, &feat_value) == 2) {
-        CFNumberRef name = CFNumberCreate(NULL, kCFNumberIntType, &feat_name);
-        CFNumberRef value = CFNumberCreate(NULL, kCFNumberIntType, &feat_value);
+      bool valid_feature = false;
+
+      if (sscanf(feature, "%d:%d", &feature_name, &feature_selector) == 2) {
+        valid_feature = true;
+      } else if (strlen(feature) == 4) {
+        get_truetype_feature(feature, &feature_name, &feature_selector);
+
+        if (feature_name != 0) {
+          valid_feature = true;
+        }
+      }
+
+      if (valid_feature) {
+        CFNumberRef name = CFNumberCreate(NULL, kCFNumberIntType, &feature_name);
+        CFNumberRef value = CFNumberCreate(NULL, kCFNumberIntType, &feature_selector);
 
         CTFontDescriptorRef new_descriptor = CTFontDescriptorCreateCopyWithFeature(descriptor, name, value);
         CFRelease(descriptor);

--- a/src/font.c
+++ b/src/font.c
@@ -65,7 +65,9 @@ void font_create_ctfont(struct font* font) {
         CFNumberRef name = CFNumberCreate(NULL, kCFNumberIntType, &feat_name);
         CFNumberRef value = CFNumberCreate(NULL, kCFNumberIntType, &feat_value);
 
-        descriptor = CTFontDescriptorCreateCopyWithFeature(descriptor, name, value);
+        CTFontDescriptorRef new_descriptor = CTFontDescriptorCreateCopyWithFeature(descriptor, name, value);
+        CFRelease(descriptor);
+        descriptor = new_descriptor;
 
         CFRelease(name);
         CFRelease(value);

--- a/src/font.h
+++ b/src/font.h
@@ -9,6 +9,7 @@ struct font {
   float size;
   char* family;
   char* style;
+  char* features;
 };
 
 void font_register(char* font_path);

--- a/src/misc/defines.h
+++ b/src/misc/defines.h
@@ -81,6 +81,7 @@
 #define PROPERTY_FONT_FAMILY                   "family"
 #define PROPERTY_FONT_STYLE                    "style"
 #define PROPERTY_FONT_SIZE                     "size"
+#define PROPERTY_FONT_FEATURES                 "features"
 
 #define PROPERTY_UPDATES                       "updates"
 #define PROPERTY_POSITION                      "position"


### PR DESCRIPTION
Adds support for [TrueType font features](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM09/AppendixF.html)

You can use OpenType font features too, but you need to go through the docs, or `<CoreText/SFNTLayoutTypes.h>` to find the corresponding TrueType codes.


For example, the C code is:

```c
int feat_name = kNumberSpacingType; // = 6
int feat_value = kMonospacedNumbersSelector; // = 0

CFNumberRef name = CFNumberCreate(default_allocator, kCFNumberIntType, &feat_name);
CFNumberRef value = CFNumberCreate(default_allocator, kCFNumberIntType, &feat_value);

descriptor = CTFontDescriptorCreateCopyWithFeature(descriptor, name, value);
```

The corresponding way to do this now is:
```sh
# one feature
sketchybar --set item label.font.features="6:0"
# multiple features
sketchybar --set item label.font.features="6:0,37:1"
```

I'm not sure if there is a nicer way of doing this though

Closes #670
In the above issue, the corresponding features string would be `"14:4"` (`kTypographicExtras`, `kSlashedZeroOnSelector`)

Related: #187

