### PR TITLE
Add new battery_change event

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-CFLAGS   = -std=c99 -Wall -Ofast -ffast-math -fvisibility=hidden -fno-common
+CFLAGS   = -std=c99 -Wall -O3 -ffast-math -fvisibility=hidden -fno-common
 
 LIBS     = -framework Carbon \
 					 -framework AppKit \
@@ -18,7 +18,7 @@ _OBJ = alias.o background.o bar_item.o custom_events.o event.o graph.o \
 			 image.o mouse.o shadow.o font.o text.o message.o mouse.o bar.o color.o \
 			 window.o bar_manager.o display.o group.o mach.o popup.o \
 			 animation.o workspace.om volume.o slider.o power.o wifi.om media.om \
-			 hotload.o app_windows.o
+			 hotload.o app_windows.o battery.o
 
 OBJ  = $(patsubst %, $(ODIR)/%, $(_OBJ))
 

--- a/src/bar_manager.c
+++ b/src/bar_manager.c
@@ -7,6 +7,7 @@
 #include "wifi.h"
 #include "volume.h"
 #include "power.h"
+#include "battery.h"
 #include "mouse.h"
 #include "media.h"
 #include "app_windows.h"
@@ -546,6 +547,7 @@ void bar_manager_update(struct bar_manager* bar_manager, bool forced) {
     forced_volume_event();
     forced_brightness_event();
     forced_power_event();
+    forced_battery_event();
     forced_front_app_event();
     forced_media_change_event();
     forced_space_windows_event();
@@ -894,6 +896,16 @@ void bar_manager_handle_power_source_change(struct bar_manager* bar_manager, cha
   env_vars_set(&env_vars, string_copy("INFO"), string_copy(state));
   bar_manager_custom_events_trigger(bar_manager,
                                     COMMAND_SUBSCRIBE_POWER_SOURCE_CHANGE,
+                                    &env_vars                             );
+  env_vars_destroy(&env_vars);
+}
+
+void bar_manager_handle_battery_change(struct bar_manager* bar_manager, char* state) {
+  struct env_vars env_vars;
+  env_vars_init(&env_vars);
+  env_vars_set(&env_vars, string_copy("INFO"), string_copy(state));
+  bar_manager_custom_events_trigger(bar_manager,
+                                    COMMAND_SUBSCRIBE_BATTERY_CHANGE,
                                     &env_vars                             );
   env_vars_destroy(&env_vars);
 }

--- a/src/bar_manager.h
+++ b/src/bar_manager.h
@@ -122,6 +122,7 @@ void bar_manager_handle_volume_change(struct bar_manager* bar_manager, float vol
 void bar_manager_handle_wifi_change(struct bar_manager* bar_manager, char* ssid);
 void bar_manager_handle_brightness_change(struct bar_manager* bar_manager, float brightness);
 void bar_manager_handle_power_source_change(struct bar_manager* bar_manager, char* state);
+void bar_manager_handle_battery_change(struct bar_manager* bar_manager, char* state);
 void bar_manager_handle_media_change(struct bar_manager* bar_manager, char* info);
 void bar_manager_handle_media_cover_change(struct bar_manager* bar_manager, CGImageRef image);
 void bar_manager_handle_space_windows_change(struct bar_manager* bar_manager, char* info);

--- a/src/battery.c
+++ b/src/battery.c
@@ -1,0 +1,99 @@
+#include "battery.h"
+#include "event.h"
+
+/* Put escaped quotation marks around something */
+#define q(x) "\""x"\""
+
+void battery_handler(void *context) {
+  /* Power source (UPS Power, Battery Power, AC Power) */
+  char source[16];
+
+  /* Battery health (Poor, Fair, Good) */
+  char health[8];
+
+  /* Battery capacities */
+  int current, max = 1;
+  double percentage = -1;
+
+  /* Time to full/empty (minutes) */
+  int empty, full;
+
+  /* Transport (Serial, USB, Ethernet, Internal) */
+  char transport[16];
+
+  /* Final JSON payload to be posted */
+  char json[1024];
+
+  /* Get the list of power sources */
+  CFTypeRef info = IOPSCopyPowerSourcesInfo();
+  CFArrayRef sources = IOPSCopyPowerSourcesList(info);
+
+  /* Loop through each power source */
+  /* TODO: What if there is more than one power source? */
+  for (CFIndex i = 0; i < CFArrayGetCount(sources); ++i) {
+    /* Dictionary containing health, capacity, charging, and transport data */
+    CFDictionaryRef cfDescription = IOPSGetPowerSourceDescription(info, CFArrayGetValueAtIndex(sources, i));
+    if (!cfDescription) continue;
+
+    /* Source */
+    CFStringRef cfSource = IOPSGetProvidingPowerSourceType(info);
+    CFStringGetCString(cfSource, source, sizeof(source), kCFStringEncodingUTF8);
+
+    /* Health */
+    CFStringRef cfHealth = CFDictionaryGetValue(cfDescription, CFSTR(kIOPSBatteryHealthKey));
+    CFStringGetCString(cfHealth, health, sizeof(health), kCFStringEncodingUTF8);
+
+    /* Capacity */
+    CFNumberRef currentCap = CFDictionaryGetValue(cfDescription, CFSTR(kIOPSCurrentCapacityKey));
+    CFNumberRef maxCap = CFDictionaryGetValue(cfDescription, CFSTR(kIOPSMaxCapacityKey));
+
+    if (currentCap && maxCap) {
+      CFNumberGetValue(currentCap, kCFNumberIntType, &current);
+      CFNumberGetValue(maxCap, kCFNumberIntType, &max);
+
+      percentage = ((double) current / (double) max) * 100;
+    }
+
+    /* Time to full/empty */
+    CFNumberRef cfFull = CFDictionaryGetValue(cfDescription, CFSTR(kIOPSTimeToFullChargeKey));
+    CFNumberGetValue(cfFull, kCFNumberIntType, &full);
+
+    CFNumberRef cfEmpty = CFDictionaryGetValue(cfDescription, CFSTR(kIOPSTimeToEmptyKey));
+    CFNumberGetValue(cfEmpty, kCFNumberIntType, &empty);
+
+    /* Transport */
+    CFStringRef cfTransport = CFDictionaryGetValue(cfDescription, CFSTR(kIOPSTransportTypeKey));
+    CFStringGetCString(cfTransport, transport, sizeof(transport), kCFStringEncodingUTF8);
+
+    /* Charging */
+    CFBooleanRef charging = CFDictionaryGetValue(cfDescription, CFSTR(kIOPSIsChargingKey));
+
+    /* Post event in JSON format */
+    snprintf(json, sizeof(json),
+	     /* source      health      percentage current max     charge  empty   full    transport */
+             "{ %s: \"%s\", %s: \"%s\", %s: %0.0f, %s: %d, %s: %d, %s: %s, %s: %d, %s: %d, %s: \"%s\" }",
+             q("source"), source,
+             q("health"), health,
+	     q("percentage"), percentage,
+	     q("current"), current,
+             q("max"), max,
+	     q("charging"), ((charging == kCFBooleanTrue) ? "true" : "false"),
+	     q("empty"), empty,
+	     q("full"), full,
+	     q("transport"), transport);
+    struct event event = {(void *)json, BATTERY_CHANGED};
+    event_post(&event);
+  }
+
+  CFRelease(info);
+  CFRelease(sources);
+}
+
+void forced_battery_event() {
+  battery_handler(NULL);
+}
+
+void begin_receiving_battery_events() {
+  CFRunLoopSourceRef source = IOPSNotificationCreateRunLoopSource(battery_handler, NULL);
+  CFRunLoopAddSource(CFRunLoopGetCurrent(), source, kCFRunLoopDefaultMode);
+}

--- a/src/battery.h
+++ b/src/battery.h
@@ -1,0 +1,5 @@
+#include <IOKit/ps/IOPowerSources.h>
+#include <IOKit/ps/IOPSKeys.h>
+
+void forced_battery_event();
+void begin_receiving_battery_events();

--- a/src/custom_events.c
+++ b/src/custom_events.c
@@ -35,6 +35,7 @@ void custom_events_init(struct custom_events* custom_events) {
   custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_VOLUME_CHANGE), NULL);
   custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_BRIGHTNESS_CHANGE), NULL);
   custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_POWER_SOURCE_CHANGE), NULL);
+  custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_BATTERY_CHANGE), NULL);
   custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_WIFI_CHANGE), NULL);
   custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_MEDIA_CHANGE), NULL);
   custom_events_append(custom_events, string_copy(COMMAND_SUBSCRIBE_SPACE_WINDOWS_CHANGE), NULL);

--- a/src/custom_events.h
+++ b/src/custom_events.h
@@ -19,6 +19,7 @@
 #define UPDATE_WIFI_CHANGE          (1ULL << 15)
 #define UPDATE_MEDIA_CHANGE         (1ULL << 16)
 #define UPDATE_SPACE_WINDOWS_CHANGE (1ULL << 17)
+#define UPDATE_BATTERY_CHANGE       (1ULL << 18)
 
 extern void* g_workspace_context;
 extern void workspace_create_custom_observer(void** context, char* name);

--- a/src/event.c
+++ b/src/event.c
@@ -324,6 +324,10 @@ static void event_power_source_changed(void* context) {
   bar_manager_handle_power_source_change(&g_bar_manager, (char*)context);
 }
 
+static void event_battery_changed(void* context) {
+  bar_manager_handle_battery_change(&g_bar_manager, (char*)context);
+}
+
 static void event_media_changed(void* context) {
   bar_manager_handle_media_change(&g_bar_manager, (char*)context);
 }
@@ -372,6 +376,7 @@ static callback_type* event_handler[] = {
   [MACH_MESSAGE]               = event_mach_message,
   [HOTLOAD]                    = event_hotload,
   [SPACE_WINDOWS_CHANGED]      = event_space_windows_changed,
+  [BATTERY_CHANGED]            = event_battery_changed,
 };
 
 void event_post(struct event *event) {

--- a/src/event.h
+++ b/src/event.h
@@ -33,6 +33,7 @@ enum event_type {
   HOTLOAD,
 
   INIT_MUTEX,
+  BATTERY_CHANGED,
   EVENT_TYPE_COUNT
 };
 

--- a/src/message.c
+++ b/src/message.c
@@ -8,6 +8,7 @@
 #include "media.h"
 #include "wifi.h"
 #include "power.h"
+#include "battery.h"
 
 extern struct bar_manager g_bar_manager;
 
@@ -94,6 +95,8 @@ static void handle_domain_trigger(FILE* rsp, struct token domain, char* message)
     forced_network_event();
   } else if (token_equals(event, COMMAND_SUBSCRIBE_POWER_SOURCE_CHANGE)) {
     forced_power_event();
+  } else if (token_equals(event, COMMAND_SUBSCRIBE_BATTERY_CHANGE)) {
+    forced_battery_event();
   } else {
     bar_manager_custom_events_trigger(&g_bar_manager, event.text, &env_vars);
   }

--- a/src/misc/defines.h
+++ b/src/misc/defines.h
@@ -128,6 +128,7 @@
 #define COMMAND_SUBSCRIBE_WIFI_CHANGE          "wifi_change"
 #define COMMAND_SUBSCRIBE_BRIGHTNESS_CHANGE    "brightness_change"
 #define COMMAND_SUBSCRIBE_POWER_SOURCE_CHANGE  "power_source_change"
+#define COMMAND_SUBSCRIBE_BATTERY_CHANGE       "battery_change"
 #define COMMAND_SUBSCRIBE_MEDIA_CHANGE         "media_change"
 #define COMMAND_SUBSCRIBE_MOUSE_ENTERED        "mouse.entered"
 #define COMMAND_SUBSCRIBE_MOUSE_EXITED         "mouse.exited"

--- a/src/sketchybar.c
+++ b/src/sketchybar.c
@@ -5,6 +5,7 @@
 #include "mouse.h"
 #include "message.h"
 #include "power.h"
+#include "battery.h"
 #include "wifi.h"
 #include "misc/help.h"
 #include "media.h"
@@ -230,6 +231,7 @@ int main(int argc, char **argv) {
     error("%s: could not initialize daemon! abort..\n", g_name);
 
   begin_receiving_power_events();
+  begin_receiving_battery_events();
   begin_receiving_network_events();
   initialize_media_events();
 


### PR DESCRIPTION
This creates a new event: **battery_change**. It receives the same notifications as power_source_change, and returns more information in JSON format.

```json
{
  "source": "Battery Power",
  "health": "Good",
  "percentage": 97,
  "current": 97,
  "max": 100,
  "charging": false,
  "empty": 541,
  "full": 0,
  "transport": "Internal"
}
```