### PR TITLE
build: replace deprecated '-Ofast' flag with '-O3'

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-CFLAGS   = -std=c99 -Wall -Ofast -ffast-math -fvisibility=hidden -fno-common
+CFLAGS   = -std=c99 -Wall -O3 -ffast-math -fvisibility=hidden -fno-common
 
 LIBS     = -framework Carbon \
 					 -framework AppKit \


### PR DESCRIPTION
Minor low-priority fix to resolve the `clang: warning: argument '-Ofast' is deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations [-Wdeprecated-ofast]` build warnings on later command line tools clang versions (I'm on Apple clang version 17.0.0 (clang-1700.3.19.1), on Sequoia 15.6.1).

From what I'm reading, '-Ofast' pretty much just enabled both '-O3' and '-ffast-math'. We already have the latter, so we can just replace '-Ofast'.

I noticed it's been brought up in some other open PRs too :) But this dedicated PR is literally a one-liner for the makefile:
```diff
-CFLAGS   = -std=c99 -Wall -Ofast -ffast-math -fvisibility=hidden -fno-common
+CFLAGS   = -std=c99 -Wall -O3 -ffast-math -fvisibility=hidden -fno-common
```

The program functioned fine despite the warnings, so this is low-priority. I've tested for a few hours with this flag, using Sketchybar like normal, and encountered no issues.

Thanks Felix & all! Sketchybar is great!