### PR TITLE
add x_offset for background

### DIFF
--- a/src/background.h
+++ b/src/background.h
@@ -8,6 +8,7 @@ struct background {
 
   int padding_left;
   int padding_right;
+  int x_offset;
   int y_offset;
   uint32_t border_width;
   uint32_t corner_radius;

--- a/src/bar_item.c
+++ b/src/bar_item.c
@@ -579,7 +579,7 @@ void bar_item_remove_window(struct bar_item* bar_item, uint32_t adid) {
 }
 
 CGPoint bar_item_calculate_shadow_offsets(struct bar_item* bar_item) {
-  CGPoint offset; 
+  CGPoint offset;
   offset.x = (int)((bar_item->background.shadow.enabled
                 ? max(-bar_item->background.shadow.offset.x, 0)
                 : 0)
@@ -594,6 +594,9 @@ CGPoint bar_item_calculate_shadow_offsets(struct bar_item* bar_item) {
                 : 0)
              + (bar_item->label.shadow.enabled
                 ? max(-bar_item->label.shadow.offset.x, 0)
+                : 0)
+             + (bar_item->background.enabled
+                ? max(-bar_item->background.x_offset, 0)
                 : 0));
 
   offset.y = (int)((bar_item->background.shadow.enabled
@@ -610,6 +613,9 @@ CGPoint bar_item_calculate_shadow_offsets(struct bar_item* bar_item) {
                  : 0)
               + (bar_item->label.shadow.enabled
                  ? max(bar_item->label.shadow.offset.x, 0)
+                 : 0)
+              + (bar_item->background.enabled
+                 ? max(bar_item->background.x_offset, 0)
                  : 0));
   return offset;
 }

--- a/src/misc/defines.h
+++ b/src/misc/defines.h
@@ -91,6 +91,7 @@
 #define PROPERTY_SCRIPT                        "script"
 #define PROPERTY_CLICK_SCRIPT                  "click_script"
 #define PROPERTY_ICON                          "icon"
+#define PROPERTY_XOFFSET                       "x_offset"
 #define PROPERTY_YOFFSET                       "y_offset"
 #define PROPERTY_WIDTH                         "width"
 #define PROPERTY_LABEL                         "label"


### PR DESCRIPTION
Added an `x_offset` property for backgrounds that can help achieve looks like this
<img width="122" height="43" alt="image" src="https://github.com/user-attachments/assets/53f3c688-aee4-4781-bc83-a2fb75113f90" />

Note: this expands the size of the item