### PR TITLE
Fix background_calculate_bounds to use given height

### DIFF
--- a/src/background.c
+++ b/src/background.c
@@ -170,7 +170,7 @@ void background_clip_bar(struct background* background, int offset, struct bar* 
 
 void background_calculate_bounds(struct background* background, uint32_t x, uint32_t y, uint32_t width, uint32_t height) {
   background->bounds.origin.x = x;
-  background->bounds.origin.y = y - background->bounds.size.height / 2;
+  background->bounds.origin.y = y - height / 2;
   background->bounds.size.width = width;
   background->bounds.size.height = height;
 


### PR DESCRIPTION
This fixes #791, so the background height is properly calculated during the first render when it wasn't explicitly set.