### PR TITLE
Use NSScreen.visibleFrame for menu bar inset on arm64

### DIFF
--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ SRC      = src
 
 _OBJ = alias.o background.o bar_item.o custom_events.o event.o graph.o \
 			 image.o mouse.o shadow.o font.o text.o message.o mouse.o bar.o color.o \
-			 window.o bar_manager.o display.o group.o mach.o popup.o \
+			 window.o bar_manager.o display.o display_nsscreen.om group.o mach.o popup.o \
 			 animation.o workspace.om volume.o slider.o power.o wifi.om media.om \
 			 hotload.o app_windows.o
 

--- a/src/display.c
+++ b/src/display.c
@@ -1,4 +1,5 @@
 #include "display.h"
+#include "display_nsscreen.h"
 #include "misc/helpers.h"
 
 extern int workspace_display_notch_height(uint32_t did);
@@ -248,11 +249,16 @@ CGRect display_menu_bar_rect(uint32_t did) {
   #ifdef __x86_64__
   SLSGetRevealedMenuBarBounds(&bounds, g_connection, display_space_id(did));
   #elif __arm64__
-  int notch_height = workspace_display_notch_height(did);
-  if (notch_height) {
-    bounds.size.height = notch_height + 6;
+  int top_inset = display_nsscreen_top_inset(did);
+  if (top_inset >= 0) {
+    bounds.size.height = top_inset;
   } else {
-    bounds.size.height = 24;
+    int notch_height = workspace_display_notch_height(did);
+    if (notch_height) {
+      bounds.size.height = notch_height + 6;
+    } else {
+      bounds.size.height = 24;
+    }
   }
 
   bounds.size.width = CGDisplayPixelsWide(did);

--- a/src/display_nsscreen.h
+++ b/src/display_nsscreen.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <stdint.h>
+
+int display_nsscreen_top_inset(uint32_t did);

--- a/src/display_nsscreen.m
+++ b/src/display_nsscreen.m
@@ -1,0 +1,25 @@
+#include "display_nsscreen.h"
+
+#import <AppKit/AppKit.h>
+
+int display_nsscreen_top_inset(uint32_t did) {
+  @autoreleasepool {
+    for (NSScreen* screen in [NSScreen screens]) {
+      NSNumber* screen_number = screen.deviceDescription[@"NSScreenNumber"];
+      if (!screen_number || screen_number.unsignedIntValue != did) continue;
+
+      NSRect frame = screen.frame;
+      NSRect visible_frame = screen.visibleFrame;
+      CGFloat top_inset = NSMaxY(frame) - NSMaxY(visible_frame);
+
+      // visibleFrame includes the full reserved strip above normal app windows.
+      // On Tahoe that is one pixel taller than the visually aligned menu-bar area,
+      // so subtract one pixel to keep SketchyBar flush with the native menu bar.
+      top_inset -= 1;
+      if (top_inset < 0) top_inset = 0;
+      return (int)(top_inset + 0.5);
+    }
+  }
+
+  return -1;
+}


### PR DESCRIPTION
This fixes SketchyBar bar placement on macOS Tahoe / macOS 26 on Apple Silicon by using the real per-display top inset from AppKit instead of the current hardcoded arm64 menu bar height values.

## Problem

On macOS Tahoe, SketchyBar is misplaced vertically on both built-in and external displays when using the current arm64 code path in `display_menu_bar_rect()`.

Current behavior uses hardcoded values:
- notched display: `notch_height + 6`
- non-notched display: `24`

On my machine those values are no longer correct on Tahoe:
- external display: the bar renders too high and ends up partially hidden behind the native menu bar
- built-in display: the bar also renders with incorrect vertical alignment

## Fix

This PR changes the arm64 menu bar inset calculation to:

1. Find the matching `NSScreen` for the display ID
2. Compute the top reserved inset from:
   - `NSMaxY(screen.frame) - NSMaxY(screen.visibleFrame)`
3. Subtract `1px` from that value before using it

The `-1` is intentional:
- on Tahoe, `visibleFrame` includes one extra reserved pixel below the visually aligned menu bar edge
- without this adjustment, SketchyBar sits `1px` too low and leaves a visible gap under the native menu bar
- with the adjustment, the bar is flush on both tested displays

If `NSScreen` lookup fails, the previous hardcoded arm64 behavior is preserved as a fallback.

## Why this approach

This keeps the change small and localized:
- x86 path is unchanged
- existing fallback behavior is unchanged
- only the arm64 menu bar geometry path is updated
- no config changes are required

## Tested

Tested on:
- Apple Silicon
- macOS Tahoe / macOS 26
- built-in display
- external display
- both displays connected

Relevant setup shape during testing:

```sh
# sketchybarrc
BAR_HEIGHT=16

sketchybar --bar \
  position=top \
  height=$BAR_HEIGHT \
  padding_left=0 \
  padding_right=0 \
  blur_radius=0 \
  sticky=on \
  display=all
```

```toml
# aerospace.toml
[gaps]
outer.top = 16
```

My SketchyBar setup is driven by AeroSpace events and renders window items for the focused workspace, so with both displays connected I verified bar placement on each display by focusing that display/workspace in turn.

## Related

This appears related to Tahoe display geometry changes, but I did not find an existing issue specifically covering:
- SketchyBar being vertically hidden behind the native menu bar on an external display
- the arm64 hardcoded menu bar inset being stale on Tahoe

I did find related display-geometry work around notch-specific sizing:
- #513
- #626

## Screenshots

Built-in display:
- Before: 
<img width="1728" height="1117" alt="sketchybar-internal-before" src="https://github.com/user-attachments/assets/c1e5bb0c-a553-4468-a804-ba4431965d56" />

- After: 
<img width="1728" height="1117" alt="sketchybar-internal-after" src="https://github.com/user-attachments/assets/020d74a8-29b2-4555-9e1b-a06ccc28df83" />


External display:
- Before: 
<img width="2304" height="1296" alt="sketchybar-external-before" src="https://github.com/user-attachments/assets/5031cafe-8256-477d-8e46-8df13b3bf7af" />

- After: 
<img width="2304" height="1296" alt="sketchybar-external-after" src="https://github.com/user-attachments/assets/32657c1c-9daf-4c68-9b05-d88e33787e6e" />
