### PR TITLE
feat: SF Symbols variable-value rendering

### DIFF
--- a/makefile
+++ b/makefile
@@ -18,7 +18,7 @@ _OBJ = alias.o background.o bar_item.o custom_events.o event.o graph.o \
 			 image.o mouse.o shadow.o font.o text.o message.o mouse.o bar.o color.o \
 			 window.o bar_manager.o display.o display_nsscreen.om group.o mach.o popup.o \
 			 animation.o workspace.om volume.o slider.o power.o wifi.om media.om \
-			 hotload.o app_windows.o
+			 hotload.o app_windows.o symbol.om
 
 OBJ  = $(patsubst %, $(ODIR)/%, $(_OBJ))
 

--- a/sketchybarrc
+++ b/sketchybarrc
@@ -87,5 +87,16 @@ sketchybar --add item clock right \
            --set battery update_freq=120 script="$PLUGIN_DIR/battery.sh" \
            --subscribe battery system_woke power_source_change
 
+##### SF Symbols variable rendering (optional, macOS 13+) #####
+# Use any SF Symbol as the image source by prefixing it with "sf.". Symbols
+# with variable values (battery, wifi, speaker, ...) honor the new
+# background.image.percentage property, which accepts integers (0..100) or
+# floats (0.0..1.0) and animates via the standard --animate system.
+#
+# sketchybar --set battery background.image=sf.battery.100percent.circle \
+#                          background.image.percentage=75 \
+#                          background.image.symbol_color=0xff25be6a
+# sketchybar --animate sin 60 --set battery background.image.percentage=25
+
 ##### Force all scripts to run the first time (never do this in a script) #####
 sketchybar --update

--- a/src/image.c
+++ b/src/image.c
@@ -1,8 +1,12 @@
 #include "image.h"
 #include "misc/helpers.h"
 #include "shadow.h"
+#include "symbol.h"
 #include "workspace.h"
 #include "media.h"
+
+#define IMAGE_SYMBOL_POINT_SIZE    32.0
+#define IMAGE_SYMBOL_RASTER_SCALE  2.0
 
 void image_init(struct image* image) {
   image->enabled = false;
@@ -19,8 +23,15 @@ void image_init(struct image* image) {
   image->padding_right = 0;
   image->link = NULL;
 
+  image->is_symbol = false;
+  image->symbol_name = NULL;
+  image->variable_value = 0.f;
+  image->variable_value_mode = IMAGE_SYMBOL_MODE_AUTOMATIC;
+  image->symbol_color_set = false;
+
   shadow_init(&image->shadow);
   color_init(&image->border_color, 0xcccccccc);
+  color_init(&image->symbol_color, 0xffffffff);
 }
 
 bool image_set_enabled(struct image* image, bool enabled) {
@@ -38,11 +49,12 @@ bool image_set_link(struct image* image, struct image* link) {
 
 bool image_load(struct image* image, char* path, FILE* rsp) {
   if (!path) return false;
+  char* source = string_copy(path);
   char* app = string_copy(path);
-  if (image->path) free(image->path);
-  image->path = string_copy(path);
   char* res_path = resolve_path(path);
   CGImageRef new_image_ref = NULL;
+  char* symbol_name = NULL;
+  bool is_symbol = false;
   float scale = 1.f;
 
   struct key_value_pair app_kv = get_key_value_pair(app, '.');
@@ -55,6 +67,7 @@ bool image_load(struct image* image, char* path, FILE* rsp) {
       respond(rsp, "[!] Image: Invalid application name: '%s'\n", app_kv.value);
       free(res_path);
       free(app);
+      free(source);
       return false;
     }
   } else if (app_kv.key && app_kv.value && strcmp(app_kv.key, "space") == 0) {
@@ -65,13 +78,49 @@ bool image_load(struct image* image, char* path, FILE* rsp) {
       respond(rsp, "[!] Image: Invalid Space ID: '%s'\n", app_kv.value);
       free(res_path);
       free(app);
+      free(source);
       return false;
     }
-  } else if (strcmp(path, "media.artwork") == 0) {
+  } else if (strcmp(source, "media.artwork") == 0) {
+    if (image->path) free(image->path);
+    image->path = source;
+    source = NULL;
+    if (image->symbol_name) {
+      free(image->symbol_name);
+      image->symbol_name = NULL;
+    }
+    image->is_symbol = false;
     free(res_path);
     free(app);
     begin_receiving_media_events();
     return image_set_link(image, &g_bar_manager.current_artwork);
+  } else if (app_kv.key && app_kv.value && strcmp(app_kv.key, "sf") == 0) {
+    if (!symbol_variable_rendering_available()) {
+      respond(rsp, "[!] Image: SF Symbol variable rendering requires macOS 13 or later\n");
+      free(res_path);
+      free(app);
+      free(source);
+      return false;
+    }
+    scale = IMAGE_SYMBOL_RASTER_SCALE;
+    CGImageRef sym_image = symbol_create_image(app_kv.value,
+                                               (double)image->variable_value,
+                                               image->variable_value_mode,
+                                               IMAGE_SYMBOL_POINT_SIZE
+                                               * IMAGE_SYMBOL_RASTER_SCALE,
+                                               image->symbol_color.hex,
+                                               image->symbol_color_set);
+    if (sym_image) {
+      symbol_name = string_copy(app_kv.value);
+      is_symbol = true;
+      new_image_ref = sym_image;
+    } else {
+      respond(rsp, "[!] Image: Invalid SF Symbol name: '%s'\n", app_kv.value);
+      free(res_path);
+      free(app);
+      free(source);
+      return false;
+    }
   } else if (file_exists(res_path)) {
     CGDataProviderRef data_provider = CGDataProviderCreateWithFilename(res_path);
     if (data_provider) {
@@ -91,6 +140,7 @@ bool image_load(struct image* image, char* path, FILE* rsp) {
       respond(rsp, "[!] Image: Invalid Image Format: '%s'\n", app_kv.value);
       free(res_path);
       free(app);
+      free(source);
       return false;
     }
   }
@@ -98,21 +148,35 @@ bool image_load(struct image* image, char* path, FILE* rsp) {
     image_destroy(image);
     free(res_path);
     free(app);
+    free(source);
     return false;
   } else {
     respond(rsp, "[!] Image: File '%s' not found\n", res_path);
     free(res_path);
     free(app);
+    free(source);
     return false;
   }
 
   if (new_image_ref) {
-    image_set_image(image,
-                    new_image_ref,
-                    (CGRect){{0,0},
-                             {CGImageGetWidth(new_image_ref) / scale,
-                              CGImageGetHeight(new_image_ref) / scale }},
-                    true                                        );
+    bool result = image_set_image(image,
+                                  new_image_ref,
+                                  (CGRect){{0,0},
+                                           {CGImageGetWidth(new_image_ref) / scale,
+                                            CGImageGetHeight(new_image_ref) / scale }},
+                                  true                                        );
+    if (image->path) free(image->path);
+    image->path = source;
+    source = NULL;
+
+    if (image->symbol_name) free(image->symbol_name);
+    image->symbol_name = symbol_name;
+    symbol_name = NULL;
+    image->is_symbol = is_symbol;
+
+    free(res_path);
+    free(app);
+    return result;
   }
   else {
     if (new_image_ref) CFRelease(new_image_ref);
@@ -120,8 +184,10 @@ bool image_load(struct image* image, char* path, FILE* rsp) {
     fprintf(rsp, "Could not open image file at: %s\n", res_path);
   }
 
+  if (symbol_name) free(symbol_name);
   free(res_path);
   free(app);
+  free(source);
   return true;
 }
 
@@ -182,6 +248,53 @@ bool image_set_scale(struct image* image, float scale) {
   image->bounds = (CGRect){{image->bounds.origin.x, image->bounds.origin.y},
                            {image->size.width * image->scale,
                             image->size.height * image->scale}};
+  return true;
+}
+
+static bool image_render_symbol(struct image* image) {
+  if (!image->is_symbol || !image->symbol_name) return false;
+  CGImageRef new_image_ref = symbol_create_image(image->symbol_name,
+                                                 (double)image->variable_value,
+                                                 image->variable_value_mode,
+                                                 IMAGE_SYMBOL_POINT_SIZE
+                                                 * IMAGE_SYMBOL_RASTER_SCALE,
+                                                 image->symbol_color.hex,
+                                                 image->symbol_color_set);
+  if (!new_image_ref) return false;
+  return image_set_image(image,
+                         new_image_ref,
+                         (CGRect){{0,0},
+                                  {CGImageGetWidth(new_image_ref)
+                                   / IMAGE_SYMBOL_RASTER_SCALE,
+                                   CGImageGetHeight(new_image_ref)
+                                   / IMAGE_SYMBOL_RASTER_SCALE}},
+                         false);
+}
+
+bool image_set_variable_value(struct image* image, float value) {
+  if (value < 0.f) value = 0.f;
+  if (value > 1.f) value = 1.f;
+  if (image->variable_value == value) return false;
+  image->variable_value = value;
+  if (image->is_symbol) return image_render_symbol(image);
+  return false;
+}
+
+bool image_set_variable_value_mode(struct image* image, int mode) {
+  if (mode == image->variable_value_mode) return false;
+  image->variable_value_mode = mode;
+  if (image->is_symbol) return image_render_symbol(image);
+  return true;
+}
+
+bool image_set_symbol_color(struct image* image, uint32_t color) {
+  bool changed = color_set_hex(&image->symbol_color, color);
+  if (!image->symbol_color_set) {
+    image->symbol_color_set = true;
+    changed = true;
+  }
+  if (!changed) return false;
+  if (image->is_symbol) return image_render_symbol(image);
   return true;
 }
 
@@ -287,6 +400,9 @@ void image_draw(struct image* image, CGContextRef context) {
     CFRelease(path);
   }
 
+  if (image->is_symbol)
+    CGContextSetInterpolationQuality(context, kCGInterpolationHigh);
+
   CGContextDrawImage(context,
                      image->bounds,
                      image->link ? image->link->image_ref : image->image_ref);
@@ -319,12 +435,15 @@ void image_clear_pointers(struct image* image) {
   image->image_ref = NULL;
   image->data_ref = NULL;
   image->path = NULL;
+  image->symbol_name = NULL;
+  image->is_symbol = false;
 }
 
 void image_destroy(struct image* image) {
   CGImageRelease(image->image_ref);
   if (image->data_ref) CFRelease(image->data_ref);
   if (image->path) free(image->path);
+  if (image->symbol_name) free(image->symbol_name);
   image_clear_pointers(image);
 }
 
@@ -335,6 +454,25 @@ void image_serialize(struct image* image, char* indent, FILE* rsp) {
                indent, image->path,
                indent, format_bool(image->enabled),
                indent, image->scale                );
+
+  if (image->is_symbol) {
+    char* mode_name = ARGUMENT_VAR_MODE_AUTOMATIC;
+    if (image->variable_value_mode == IMAGE_SYMBOL_MODE_COLOR)
+      mode_name = ARGUMENT_VAR_MODE_COLOR;
+    else if (image->variable_value_mode == IMAGE_SYMBOL_MODE_DRAW)
+      mode_name = ARGUMENT_VAR_MODE_DRAW;
+
+    fprintf(rsp, ",\n%s\"symbol\": \"%s\""
+                 ",\n%s\"percentage\": %f"
+                 ",\n%s\"variable_value_mode\": \"%s\"",
+                 indent, image->symbol_name ? image->symbol_name : "",
+                 indent, image->variable_value,
+                 indent, mode_name                                    );
+
+    if (image->symbol_color_set)
+      fprintf(rsp, ",\n%s\"symbol_color\": \"0x%x\"",
+              indent, image->symbol_color.hex);
+  }
 }
 
 bool image_parse_sub_domain(struct image* image, FILE* rsp, struct token property, char* message) {
@@ -389,6 +527,44 @@ bool image_parse_sub_domain(struct image* image, FILE* rsp, struct token propert
                   image,
                   image->border_color.hex,
                   token_to_int(token));
+  }
+  else if (token_equals(property, PROPERTY_PERCENTAGE)) {
+    struct token token = get_token(&message);
+    float new_value;
+    if (token.length > 0 && memchr(token.text, '.', token.length)) {
+      new_value = token_to_float(token);
+    } else {
+      new_value = (float)token_to_int(token) / 100.f;
+    }
+    if (new_value < 0.f) new_value = 0.f;
+    if (new_value > 1.f) new_value = 1.f;
+    ANIMATE_FLOAT(image_set_variable_value,
+                  image,
+                  image->variable_value,
+                  new_value);
+  }
+  else if (token_equals(property, PROPERTY_SYMBOL_COLOR)) {
+    struct token token = get_token(&message);
+    ANIMATE_BYTES(image_set_symbol_color,
+                  image,
+                  image->symbol_color.hex,
+                  token_to_int(token));
+  }
+  else if (token_equals(property, PROPERTY_VARIABLE_VALUE_MODE)) {
+    struct token token = get_token(&message);
+    int mode = IMAGE_SYMBOL_MODE_AUTOMATIC;
+    if (token_equals(token, ARGUMENT_VAR_MODE_COLOR)) {
+      mode = IMAGE_SYMBOL_MODE_COLOR;
+    } else if (token_equals(token, ARGUMENT_VAR_MODE_DRAW)) {
+      mode = IMAGE_SYMBOL_MODE_DRAW;
+    } else if (!token_equals(token, ARGUMENT_VAR_MODE_AUTOMATIC)) {
+      respond(rsp,
+              "[?] Image: Invalid variable_value_mode '%.*s' "
+              "(expected automatic|color|draw)\n",
+              token.length, token.text);
+      return false;
+    }
+    needs_refresh = image_set_variable_value_mode(image, mode);
   }
   else {
     struct key_value_pair key_value_pair = get_key_value_pair(property.text,

--- a/src/image.h
+++ b/src/image.h
@@ -27,6 +27,13 @@ struct image {
   int y_offset;
 
   struct image* link;
+
+  bool is_symbol;
+  char* symbol_name;
+  float variable_value;
+  int variable_value_mode;
+  bool symbol_color_set;
+  struct color symbol_color;
 };
 
 void image_init(struct image* image);
@@ -35,6 +42,9 @@ void image_copy(struct image* image, CGImageRef source);
 bool image_set_image(struct image* image, CGImageRef new_image_ref, CGRect bounds, bool forced);
 bool image_load(struct image* image, char* path, FILE* rsp);
 bool image_set_scale(struct image* image, float scale);
+bool image_set_variable_value(struct image* image, float value);
+bool image_set_variable_value_mode(struct image* image, int mode);
+bool image_set_symbol_color(struct image* image, uint32_t color);
 
 CGSize image_get_size(struct image* image);
 void image_calculate_bounds(struct image* image, uint32_t x, uint32_t y);

--- a/src/misc/defines.h
+++ b/src/misc/defines.h
@@ -101,6 +101,8 @@
 #define PROPERTY_EVENT_PORT                    "mach_helper"
 #define PROPERTY_PERCENTAGE                    "percentage"
 #define PROPERTY_MAX_CHARS                     "max_chars"
+#define PROPERTY_VARIABLE_VALUE_MODE           "variable_value_mode"
+#define PROPERTY_SYMBOL_COLOR                  "symbol_color"
 
 #define DOMAIN_BAR                             "--bar"
 #define PROPERTY_POSITION                      "position"
@@ -166,6 +168,10 @@
 #define ARGUMENT_COMMON_VAL_TOGGLE             "toggle"
 #define ARGUMENT_COMMON_VAL_BEFORE             "before"
 #define ARGUMENT_COMMON_VAL_AFTER              "after"
+
+#define ARGUMENT_VAR_MODE_AUTOMATIC            "automatic"
+#define ARGUMENT_VAR_MODE_COLOR                "color"
+#define ARGUMENT_VAR_MODE_DRAW                 "draw"
 
 #define ARGUMENT_DISPLAY_MAIN                  "main"
 #define ARGUMENT_DISPLAY_ALL                   "all"

--- a/src/symbol.h
+++ b/src/symbol.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <CoreGraphics/CoreGraphics.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#define IMAGE_SYMBOL_MODE_AUTOMATIC 0
+#define IMAGE_SYMBOL_MODE_COLOR     1
+#define IMAGE_SYMBOL_MODE_DRAW      2
+
+// Returns true if variable-value rendering of SF Symbols is available at
+// runtime on this macOS version. Selector check; safe on macOS 10.13+ even
+// though the call sites only trigger on macOS 13+ in practice.
+bool symbol_variable_rendering_available(void);
+
+// Renders an SF Symbol image with the requested variable value. Returns a
+// retained CGImageRef the caller must CGImageRelease, or NULL if the symbol
+// name is unknown, variable rendering is unavailable, or rendering failed.
+//
+//   name       Symbol name (e.g. "battery.100percent.circle").
+//   value      Variable value in [0, 1]; clamped here as well.
+//   mode       One of IMAGE_SYMBOL_MODE_*; applied only on macOS 26+, ignored
+//              on older systems (Apple default behavior is used instead).
+//   point_size Symbol configuration point size, in points (e.g. 32.0).
+//   color      Optional ARGB tint color; applied when has_color is true.
+CGImageRef symbol_create_image(const char* name,
+                               double value,
+                               int mode,
+                               double point_size,
+                               uint32_t color,
+                               bool has_color);

--- a/src/symbol.m
+++ b/src/symbol.m
@@ -1,0 +1,106 @@
+#include "symbol.h"
+#include <AppKit/AppKit.h>
+
+// The variable-value class method on NSImage. Used as the gating selector for
+// the entire SF Symbols variable-rendering feature.
+static SEL variable_value_selector(void) {
+  return NSSelectorFromString(
+    @"imageWithSystemSymbolName:variableValue:accessibilityDescription:"
+  );
+}
+
+bool symbol_variable_rendering_available(void) {
+  return [NSImage respondsToSelector:variable_value_selector()];
+}
+
+CGImageRef symbol_create_image(const char* name,
+                               double value,
+                               int mode,
+                               double point_size,
+                               uint32_t color,
+                               bool has_color) {
+  if (!name) return NULL;
+  if (!symbol_variable_rendering_available()) return NULL;
+
+  if (value < 0.0) value = 0.0;
+  if (value > 1.0) value = 1.0;
+
+  @autoreleasepool {
+    NSString* ns_name = [NSString stringWithUTF8String:name];
+    if (!ns_name) return NULL;
+
+    NSImage* image = nil;
+    if (@available(macOS 13.0, *)) {
+      image = [NSImage imageWithSystemSymbolName:ns_name
+                                   variableValue:value
+                          accessibilityDescription:nil];
+    }
+    if (!image) return NULL;
+
+    // NSImageSymbolConfiguration is macOS 11.0+. The variable-rendering call
+    // above already requires macOS 13+, so we are always inside this branch
+    // when we have an image, but the compiler needs the explicit availability
+    // check for any reference to NSImageSymbolConfiguration.
+    if (@available(macOS 11.0, *)) {
+      NSImageSymbolConfiguration* config =
+          [NSImageSymbolConfiguration configurationWithPointSize:point_size
+                                                          weight:NSFontWeightRegular];
+
+
+      if (has_color) {
+        if (@available(macOS 12.0, *)) {
+          CGFloat alpha = ((color >> 24) & 0xff) / 255.0;
+          CGFloat red = ((color >> 16) & 0xff) / 255.0;
+          CGFloat green = ((color >> 8) & 0xff) / 255.0;
+          CGFloat blue = (color & 0xff) / 255.0;
+          NSColor* ns_color = [NSColor colorWithCalibratedRed:red
+                                                        green:green
+                                                         blue:blue
+                                                        alpha:alpha];
+          NSImageSymbolConfiguration* color_config =
+              [NSImageSymbolConfiguration configurationWithHierarchicalColor:ns_color];
+          if (color_config) {
+            config = config
+              ? [config configurationByApplyingConfiguration:color_config]
+              : color_config;
+          }
+        }
+      }
+      // Variable-value-mode configuration is macOS 26+. On older systems the
+      // mode field is parsed at the SketchyBar layer for forward-compat but
+      // not applied here, so Apple's default (automatic) rendering is used.
+      if (mode != IMAGE_SYMBOL_MODE_AUTOMATIC) {
+        if (@available(macOS 26.0, *)) {
+          NSImageSymbolVariableValueMode ns_mode =
+              NSImageSymbolVariableValueModeAutomatic;
+          if (mode == IMAGE_SYMBOL_MODE_COLOR)
+            ns_mode = NSImageSymbolVariableValueModeColor;
+          else if (mode == IMAGE_SYMBOL_MODE_DRAW)
+            ns_mode = NSImageSymbolVariableValueModeDraw;
+
+          NSImageSymbolConfiguration* mode_config =
+              [NSImageSymbolConfiguration
+                  configurationWithVariableValueMode:ns_mode];
+          if (mode_config) {
+            config = config
+              ? [config configurationByApplyingConfiguration:mode_config]
+              : mode_config;
+          }
+        }
+      }
+
+      if (config) {
+        NSImage* configured = [image imageWithSymbolConfiguration:config];
+        if (configured) image = configured;
+      }
+    }
+
+    NSRect proposed = NSMakeRect(0, 0, [image size].width, [image size].height);
+    CGImageRef cg = [image CGImageForProposedRect:&proposed
+                                          context:nil
+                                            hints:nil];
+    if (!cg) return NULL;
+    CGImageRetain(cg);
+    return cg;
+  }
+}


### PR DESCRIPTION
## Why

Adds variable-value SF Symbol rendering as a new image source. The use case is progress-style indicators (battery fill, wifi/speaker level, audio waveform, custom dials) driven by a single symbol name + percentage, without managing N pre-rendered PNGs or N font glyphs.

This is different from #63 (closed in 2021): that discussion was about *static* SF Symbols, which already work fine by pasting the glyph into `icon`/`label` text. Variable-value rendering cannot be expressed as a Unicode glyph — Apple generates a per-frame Core Graphics image from a symbol name + a `[0, 1]` value, and that image is what changes as the value changes.

## Issue links

I did not find an open issue that this should close. I searched existing issues for SF Symbols, variable/value symbols, symbol images, battery/progress indicators, image tinting, symbol color, and palette support. The closest historical issue is #43 (`SF Symbols`), but it is already closed and was about static SF Symbol support; this PR adds variable-value image rendering instead. Related discussion context: #63.

## What

Four additions to the existing `image` sub-domain. No breaking changes, no new sub-domain, no new frameworks linked.

```sh
# Use an SF Symbol as the image source.
sketchybar --set battery background.image=sf.battery.100percent.circle

# Drive the variable value. Accepts ints in 0..100 or floats in 0.0..1.0.
sketchybar --set battery background.image.percentage=75
sketchybar --set battery background.image.percentage=0.75

# Optional rendering mode (macOS 26+; accepted but ignored on older systems).
sketchybar --set battery background.image.variable_value_mode=draw

# Optional monochrome symbol tint, useful on dark/transparent bars.
sketchybar --set battery background.image.symbol_color=0xff25be6a
```

Works with `icon.background.image=`, `label.background.image=`, and `background.image=` — anywhere `image` already accepts a source.

`--query` round-trips the new fields when the image source is an SF Symbol:

```json
"image": {
  "value": "sf.battery.100percent.circle",
  "drawing": "on",
  "scale": 1.000000,
  "symbol": "battery.100percent.circle",
  "percentage": 0.750000,
  "variable_value_mode": "automatic",
  "symbol_color": "0xff25be6a"
}
```

`symbol_color` is emitted only when explicitly set, so existing configs and query output for untinted SF Symbols remain unchanged.

## How

- New `src/symbol.{h,m}` wraps `+[NSImage imageWithSystemSymbolName:variableValue:accessibilityDescription:]` behind a runtime `respondsToSelector:` check. The compile-time SDK already ships `NSImageSymbolVariableValueMode` (macOS 26), so the mode branch is guarded with `@available(macOS 26.0, *)` rather than `NSInvocation` tricks.
- `image_load` adds an `sf.*` branch alongside `app.*` and `space.*`. The existing `get_key_value_pair` splits on the first `.`, so `sf.battery.100percent.circle` correctly extracts `battery.100percent.circle` as the symbol name.
- Percentage uses the existing `ANIMATE_FLOAT` track, so `--animate sin 60 --set foo background.image.percentage=…` animates for free. Verified locally — 0.42 → 1.0 over 60 ticks interpolates correctly.
- `symbol_color` uses `NSImageSymbolConfiguration configurationWithHierarchicalColor:` when set. This is intentionally narrow: one ARGB tint for monochrome symbols. Palette, multicolor, and symbol-rendering-style configuration are still left out.
- SF Symbol images are rasterized at 2x the logical symbol size and drawn with high interpolation. Other image sources keep the existing global `kCGInterpolationNone` behavior.
- `image_set_image`'s data-`memcmp` dedup short-circuits the redraw when the re-rendered symbol pixels are identical to the previous frame, so no churn at steady state. No extra cache layer needed.
- Dual-unit percentage parse: a literal `.` in the token routes through `token_to_float` (Apple's native units); otherwise the token parses as an int and is divided by 100 (matches `slider.percentage` semantics).
- Switching the image source away from `sf.*` clears the symbol state cleanly (verified via `--query` round-trip). Symbol name is duplicated into `image->symbol_name` and freed in `image_destroy`/`image_clear_pointers`.

## Compatibility

- Build targets unchanged: `x86_64-apple-macos10.13` and `arm64-apple-macos11`.
- `make x86`, `make arm64`, `make universal` all build with zero new warnings on Xcode 26.5 / SDK MacOSX26.5.
- Variable rendering itself requires macOS 13 or later (Apple API gate). On earlier macOS releases the `sf.` prefix is rejected with a clear error message; everything else (file paths, `app.*`, `space.*`, `media.artwork`) continues to work unchanged.
- No new linker flags. `AppKit` is already linked.

## Out of scope (intentional — happy to follow up if useful)

- **Palette / multicolor tinting** via `NSImageSymbolConfiguration` palette colors or explicit rendering-style controls. This PR only adds the minimal monochrome `symbol_color` tint needed to make SF Symbol images usable across light, dark, and transparent bars.
- **Native SF Symbol animations** (bounce, pulse, scale, replace, variableColor cumulative). These need an offscreen `NSImageView` cache / per-item renderer change and felt too large for this PR.
- **Symbol weight / scale axes** beyond the implicit 32pt regular baseline, matching `workspace_icon_for_app`'s sizing.

## Verification done locally

- All three build flavors (`x86`, `arm64`, `universal`) build clean.
- Unit-level tests (separate small program linking `symbol.o`) confirm: invalid names return `NULL`; valid names return distinct pixel data for different values; same params produce byte-identical output (dedup property); out-of-range values clamp.
- Integration via the built binary: percentage as int and as float, mode round-trip, symbol tint round-trip, animation interpolation, switching source from `sf.*` to a file path and back — all verified through `--query` JSON.
- Visual smoke with `sf.circle` + `symbol_color=0xff78a9ff` confirms tinted variable-draw output renders without a PNG fallback.
