### PR TITLE
feat: optionally use typographical width

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -156,6 +156,7 @@ void font_init(struct font* font) {
   font->size = 14.f;
   font->style = string_copy("Bold");
   font->family = string_copy("Hack Nerd Font");
+  font->typographical_width = false;
   font_create_ctfont(font);
 }
 
@@ -189,6 +190,15 @@ bool font_set_size(struct font* font, float size) {
   if (font->size == size) return false;
 
   font->size = size;
+  font->font_changed = true;
+
+  return true;
+}
+
+bool font_set_typographical_width(struct font* font, bool typographical_width) {
+  if (font->typographical_width == typographical_width) return false;
+
+  font->typographical_width = typographical_width;
   font->font_changed = true;
 
   return true;
@@ -259,6 +269,9 @@ bool font_parse_sub_domain(struct font* font, FILE* rsp, struct token property, 
   } else if (token_equals(property, PROPERTY_FONT_FEATURES)) {
     struct token token = get_token(&message);
     needs_refresh = font_set_features(font, token_to_string(token));
+  } else if (token_equals(property, PROPERTY_FONT_TYPOGRAPHICAL_WIDTH)) {
+    struct token token = get_token(&message);
+    needs_refresh = font_set_typographical_width(font, evaluate_boolean_state(token, font->typographical_width));
   } else {
     respond(rsp, "[!] Text: Invalid property '%s'\n", property.text);
   }

--- a/src/font.h
+++ b/src/font.h
@@ -6,6 +6,7 @@ struct font {
   CTFontRef ct_font;
 
   bool font_changed;
+  bool typographical_width;
   float size;
   char* family;
   char* style;
@@ -20,6 +21,7 @@ bool font_set(struct font* font, char* font_string, bool forced);
 bool font_set_size(struct font* font, float size);
 bool font_set_family(struct font* font, char* family, bool forced);
 bool font_set_style(struct font* font, char* style, bool forced);
+bool font_set_typographical_width(struct font* font, bool typographical_width);
 void font_create_ctfont(struct font* font);
 void font_clear_pointers(struct font* font);
 

--- a/src/misc/defines.h
+++ b/src/misc/defines.h
@@ -82,6 +82,7 @@
 #define PROPERTY_FONT_STYLE                    "style"
 #define PROPERTY_FONT_SIZE                     "size"
 #define PROPERTY_FONT_FEATURES                 "features"
+#define PROPERTY_FONT_TYPOGRAPHICAL_WIDTH      "typographical_width"
 
 #define PROPERTY_UPDATES                       "updates"
 #define PROPERTY_POSITION                      "position"

--- a/src/text.c
+++ b/src/text.c
@@ -69,20 +69,26 @@ static void text_prepare_line(struct text* text) {
 
   text->line.line = CTLineCreateWithAttributedString(attr_string);
 
-  CTLineGetTypographicBounds(text->line.line,
-                             &text->line.ascent,
-                             &text->line.descent,
-                             NULL                );
+  double typographic_width = CTLineGetTypographicBounds(text->line.line,
+                                                        &text->line.ascent,
+                                                        &text->line.descent,
+                                                        NULL                );
 
   text->bounds = CTLineGetBoundsWithOptions(text->line.line,
                                             kCTLineBoundsUseGlyphPathBounds);
 
+  // extra 1px padding for width and height to prevent clipping
   text->bounds.size.width = (uint32_t) (text->bounds.size.width + 1.5);
   text->bounds.size.height = (uint32_t) (text->bounds.size.height + 1.5);
   text->bounds.origin.x = (int32_t) (text->bounds.origin.x + 0.5);
   text->bounds.origin.y = (int32_t) (text->bounds.origin.y + 0.5);
 
-  text->width = text->bounds.size.width;
+  // when typographical_width is enabled, we don't need the extra 1px padding
+  // to prevent clipping, as it already accounts for the full advance width
+  if (text->font.typographical_width)
+    text->width = (uint32_t) (typographic_width + 0.5);
+  else
+    text->width = text->bounds.size.width;
 
   CFRelease(string);
   CFRelease(attr_string);
@@ -122,6 +128,7 @@ void text_copy(struct text* text, struct text* source) {
   font_set_family(&text->font, string_copy(source->font.family), true);
   font_set_style(&text->font, string_copy(source->font.style), true);
   font_set_size(&text->font, source->font.size);
+  font_set_typographical_width(&text->font, source->font.typographical_width);
   text_set_string(text, string_copy(source->string), true);
 }
 


### PR DESCRIPTION
This is a follow-up to #692 that added font features like tnum.

After that PR, `tnum` would not work properly, because we weren't using the right attribute to decide on character width.

`CTLineGetBoundsWithOptions` gets us the actual bounds where the character is drawn, but we actually need to use `CTLineGetTypographicBounds` so that we can properly render the extra spacing for each character.

This PR introduces a `typographical_width` option to the font field that enables using the slightly larger bounds for each character.

I added this as off by default because this otherwise, it would be a breaking change and makes every (most?) item slightly wider than before.

Now, `tnum` will actually work properly.

example using the SF Pro font:

Before this patch (without `tnum`): observe lots of jumping around

https://github.com/user-attachments/assets/584695dc-e94a-47ec-8127-da76b3134a19


Before the patch (with `tnum`): exact same as without tnum

https://github.com/user-attachments/assets/7038ac38-51db-4681-bf53-2a5a1b77f98f

After the patch (with `typographical_width` and `tnum): no jumping around

https://github.com/user-attachments/assets/a573ef3c-059e-4796-9bf4-2e8d67026bb3

Looking at the actual widths, the issue and fix is a lot more clear:

|method|0|1|2|3|4|5|6|7|8|9|
|------|-|-|-|-|-|-|-|-|-|-|
|pre pr| 5.789 | 3.100 | 5.801 | 5.865 | 5.971 | 5.777 | 5.754 | 5.836 | 5.766 | 5.672 |
|pre pr,tnum| 5.789 | 3.100 | 5.801 | 5.865 | 5.971 | 5.777 | 5.754 | 5.836 | 5.766 |5.672|
|typographic,tnun| 6.674 | 6.674 | 6.674 | 6.674 | 6.674 | 6.674 | 6.674 | 6.674 | 6.674 | 6.674 |

