### PR TITLE
use opentype directly

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -2,60 +2,6 @@
 #include "animation.h"
 #include "bar_manager.h"
 
-struct feature_mapping {
-  char opentype_tag[5];
-  int truetype_feature;
-  int truetype_selector;
-};
-
-// Non-exhaustive list of OpenType tags and corresponding TrueType features and selectors
-struct feature_mapping feature_mappings[] = {
-  {"liga", kLigaturesType, kCommonLigaturesOnSelector},
-  {"dlig", kLigaturesType, kRareLigaturesOnSelector},
-
-  {"tnum", kNumberSpacingType, kMonospacedNumbersSelector}, 
-  {"pnum", kNumberSpacingType, kProportionalNumbersSelector}, 
-
-  {"smcp", kLowerCaseType, kLowerCaseSmallCapsSelector},
-  {"c2sc", kUpperCaseType, kUpperCaseSmallCapsSelector},
-
-  {"onum", kNumberCaseType, kLowerCaseNumbersSelector},
-  {"lnum", kNumberCaseType, kUpperCaseNumbersSelector},
-
-  {"afrc", kFractionsType, kVerticalFractionsSelector},
-  {"frac", kFractionsType, kDiagonalFractionsSelector},
-
-  {"subs", kVerticalPositionType, kInferiorsSelector},
-  {"sups", kVerticalPositionType, kSuperiorsSelector},
-
-  {"zero", kTypographicExtrasType, kSlashedZeroOnSelector},
-
-  {"swsh", kContextualAlternatesType, kSwashAlternatesOnSelector},
-  {"cswh", kContextualAlternatesType, kContextualSwashAlternatesOnSelector},
-
-  {"calt", kContextualAlternatesType, kContextualAlternatesOnSelector},
-
-  // kStylisticAlternativesType = 35
-  {"salt", 35,  2},
-  {"ss01", 35,  2}, {"ss02", 35, 4},  {"ss03", 35,  6}, {"ss04", 35,  8},
-  {"ss05", 35, 10}, {"ss06", 35, 12}, {"ss07", 35, 14}, {"ss08", 35, 16},
-  {"ss09", 35, 18}, {"ss10", 35, 20}, {"ss11", 35, 22}, {"ss12", 35, 24},
-  {"ss13", 35, 26}, {"ss14", 35, 28}, {"ss15", 35, 30}, {"ss16", 35, 32},
-  {"ss17", 35, 34}, {"ss18", 35, 36}, {"ss19", 35, 38}, {"ss20", 35, 40},
-
-  {"", 0, 0}
-};
-
-void get_truetype_feature(const char* opentype_tag, int* truetype_feature, int* truetype_selector) {
-  for (int i = 0; feature_mappings[i].opentype_tag[0] != '\0'; ++i) {
-    if (strcmp(feature_mappings[i].opentype_tag, opentype_tag) == 0) {
-      *truetype_feature = feature_mappings[i].truetype_feature;
-      *truetype_selector = feature_mappings[i].truetype_selector;
-      return;
-    }
-  }
-}
-
 void font_register(char* font_path) {
   CFStringRef url_string = CFStringCreateWithCString(kCFAllocatorDefault,
                                                      font_path,
@@ -109,37 +55,88 @@ void font_create_ctfont(struct font* font) {
     char* features_copy = string_copy(font->features);
     char* feature = strtok(features_copy, ",");
 
+    CFMutableArrayRef settings = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
+
     while (feature) {
       int feature_name = 0;
       int feature_selector = 0;
 
-      bool valid_feature = false;
-
       if (sscanf(feature, "%d:%d", &feature_name, &feature_selector) == 2) {
-        valid_feature = true;
-      } else if (strlen(feature) == 4) {
-        get_truetype_feature(feature, &feature_name, &feature_selector);
-
-        if (feature_name != 0) {
-          valid_feature = true;
-        }
-      }
-
-      if (valid_feature) {
         CFNumberRef name = CFNumberCreate(NULL, kCFNumberIntType, &feature_name);
         CFNumberRef value = CFNumberCreate(NULL, kCFNumberIntType, &feature_selector);
 
-        CTFontDescriptorRef new_descriptor = CTFontDescriptorCreateCopyWithFeature(descriptor, name, value);
-        CFRelease(descriptor);
-        descriptor = new_descriptor;
+        const void* setting_keys[] = { kCTFontFeatureTypeIdentifierKey,
+                                       kCTFontFeatureSelectorIdentifierKey };
+        const void* setting_values[] = { name, value };
 
+        CFDictionaryRef setting = CFDictionaryCreate(NULL,
+                                                     setting_keys,
+                                                     setting_values,
+                                                     array_count(setting_keys),
+                                                     &kCFTypeDictionaryKeyCallBacks,
+                                                     &kCFTypeDictionaryValueCallBacks);
+
+        CFArrayAppendValue(settings, setting);
+
+        CFRelease(setting);
         CFRelease(name);
         CFRelease(value);
+      } else {
+        // '+feat' or 'feat' to enable, '-feat' to disable
+        int feature_value = 1;
+        if (feature[0] == '+' || feature[0] == '-') {
+          feature_value = feature[0] == '+' ? 1 : 0;
+          feature++;
+        }
+
+        if (strlen(feature) != 4) {
+          feature = strtok(NULL, ",");
+          continue;
+        }
+
+        CFStringRef tag = CFStringCreateWithCString(NULL, feature, kCFStringEncodingUTF8);
+        CFNumberRef value = CFNumberCreate(NULL, kCFNumberIntType, &feature_value);
+
+        const void* setting_keys[] = { kCTFontOpenTypeFeatureTag,
+                                       kCTFontOpenTypeFeatureValue };
+        const void* setting_values[] = { tag, value };
+
+        CFDictionaryRef setting = CFDictionaryCreate(NULL,
+                                                     setting_keys,
+                                                     setting_values,
+                                                     array_count(setting_keys),
+                                                     &kCFTypeDictionaryKeyCallBacks,
+                                                     &kCFTypeDictionaryValueCallBacks);
+
+        CFArrayAppendValue(settings, setting);
+
+        CFRelease(setting);
+        CFRelease(value);
+        CFRelease(tag);
       }
 
       feature = strtok(NULL, ",");
     }
 
+    if (CFArrayGetCount(settings) > 0) {
+      const void* feature_keys[] = { kCTFontFeatureSettingsAttribute };
+      const void* feature_values[] = { settings };
+
+      CFDictionaryRef feature_attr = CFDictionaryCreate(NULL,
+                                                        feature_keys,
+                                                        feature_values,
+                                                        array_count(feature_keys),
+                                                        &kCFTypeDictionaryKeyCallBacks,
+                                                        &kCFTypeDictionaryValueCallBacks);
+
+      CTFontDescriptorRef new_descriptor = CTFontDescriptorCreateCopyWithAttributes(descriptor, feature_attr);
+      CFRelease(descriptor);
+      descriptor = new_descriptor;
+
+      CFRelease(feature_attr);
+    }
+
+    CFRelease(settings);
     free(features_copy);
   }
 


### PR DESCRIPTION
Previously, we used a roundabout way to set truetype font features, because I didn't realize we could use TrueType.

This caused issues if a font didn't support OpenType, which many (modern) fonts don't. Enabling a feature in sketchybar would thus enable a nonexistent OpenType feature.

This fixes it and now directly uses OpenType to configure everything.

This PR also adds support for `+feat`, `-feat` to explicitly enable/disable features, along with the existing plain `feat` to enable a feature.